### PR TITLE
Add safe builders

### DIFF
--- a/annotations/src/main/kotlin/com/faendir/kotlin/autodsl/AutoDsl.kt
+++ b/annotations/src/main/kotlin/com/faendir/kotlin/autodsl/AutoDsl.kt
@@ -4,4 +4,7 @@ import kotlin.reflect.KClass
 
 @Retention(AnnotationRetention.SOURCE)
 @Target(AnnotationTarget.CLASS, AnnotationTarget.TYPEALIAS)
-annotation class AutoDsl(val dslMarker: KClass<out Annotation> = Annotation::class )
+annotation class AutoDsl(
+  val dslMarker: KClass<out Annotation> = Annotation::class,
+  val safe: SafetyType = SafetyType.Unsafe,
+)

--- a/annotations/src/main/kotlin/com/faendir/kotlin/autodsl/SafetyType.kt
+++ b/annotations/src/main/kotlin/com/faendir/kotlin/autodsl/SafetyType.kt
@@ -1,0 +1,7 @@
+package com.faendir.kotlin.autodsl
+
+enum class SafetyType {
+    Unsafe,
+    AssignOnce,
+    Safe,
+}

--- a/processor/src/main/kotlin/com/faendir/kotlin/autodsl/DslGenerator.kt
+++ b/processor/src/main/kotlin/com/faendir/kotlin/autodsl/DslGenerator.kt
@@ -5,7 +5,7 @@ import com.faendir.kotlin.autodsl.parameter.ParameterFactory
 import com.google.devtools.ksp.symbol.ClassKind
 import com.squareup.kotlinpoet.*
 import io.github.enjoydambience.kotlinbard.*
-import java.util.*
+import kotlin.contracts.ExperimentalContracts
 import kotlin.jvm.internal.DefaultConstructorMarker
 import kotlin.properties.Delegates
 
@@ -24,25 +24,31 @@ class DslGenerator<A, T : A, C : A>(
     }
 
 
-    fun process(): List<T> {
-        return resolver.getClassesWithAnnotation(AutoDsl::class)
-            .flatMap { processClass(it, resolver.run { it.getAnnotationTypeProperty(AutoDsl::class, AutoDsl::dslMarker) }) }
+    fun process(): List<T> = resolver.run {
+        getClassesWithAnnotation(AutoDsl::class).flatMap {
+            processClass(
+                it,
+                it.getAnnotationTypeProperty(AutoDsl::class, AutoDsl::dslMarker),
+                it.getAnnotationProperty(AutoDsl::class, AutoDsl::safe) ?: SafetyType.Unsafe,
+            )
+        }
     }
 
-    private fun processClass(clazz: T, markerType: ClassName?): List<T> = resolver.run {
+    private fun processClass(clazz: T, markerType: ClassName?, safe: SafetyType): List<T> = resolver.run {
         when (clazz.getClassKind()) {
             ClassKind.INTERFACE -> error("must not be an interface", clazz)
             ClassKind.ENUM_CLASS -> error("must not be an enum class", clazz)
             ClassKind.ENUM_ENTRY -> error("must not be an enum entry", clazz)
             ClassKind.OBJECT -> error("must not be an object", clazz)
             ClassKind.ANNOTATION_CLASS -> {
-                val deferred = resolver.getClassesWithAnnotation(clazz).flatMap { processClass(it, markerType) }
+                val deferred = getClassesWithAnnotation(clazz).flatMap { processClass(it, markerType, safe) }
                 if (deferred.isNotEmpty()) {
                     return deferred + clazz
                 }
             }
+
             ClassKind.CLASS -> {
-                if (!generate(clazz, markerType)) {
+                if (!generate(clazz, markerType, safe)) {
                     return listOf(clazz)
                 }
             }
@@ -50,32 +56,92 @@ class DslGenerator<A, T : A, C : A>(
         emptyList()
     }
 
-    /**
-     * returns true if class generation was successful
-     */
-    private fun generate(clazz: T, markerType: ClassName?): Boolean = resolver.run {
-        if (clazz.isAbstract()) {
-            error("must not be abstract", clazz)
-            return false
+    private fun T.parameters(): List<Parameter<T>>? = resolver.run {
+        if (isAbstract()) {
+            error("must not be abstract", this@parameters)
+            return null
         }
-        val constructors = clazz.getConstructors().filter { it.isAccessible() }
+        val constructors = getConstructors().filter { it.isAccessible() }
         if (constructors.isEmpty()) {
-            error("must have at least one public or internal constructor", clazz)
-            return false
+            error("must have at least one public or internal constructor", this@parameters)
+            return null
         }
         val constructor = constructors.firstOrNull { it.hasAnnotation(AutoDslConstructor::class) }
-            ?: clazz.getPrimaryConstructor()
+            ?: getPrimaryConstructor()
             ?: constructors.first()
         if (!constructor.isValid()) {
             //defer processing
-            return false
+            return null
         }
-        val parameters = parameterFactory.getParameters(constructor)
+        return parameterFactory.getParameters(constructor)
+    }
+
+    private fun ClassName.parameterInterface(parameter: Parameter<T>): ClassName = nestedClass(parameter.group)
+
+    /**
+     * returns true if class generation was successful
+     */
+    private fun generate(clazz: T, markerType: ClassName?, safe: SafetyType): Boolean = resolver.run {
+        val parameters = clazz.parameters() ?: return false
+        val requiredParameters = parameters.filter { it.isMandatory }
+        val requiredGroups = requiredParameters.groupBy { it.group }.values
         val type = clazz.asClassName()
         val builderType = type.withBuilderSuffix()
         val bitFieldIndices = 0..parameters.size / 32
+        val isSafe = safe != SafetyType.Unsafe
+        val builderTypeImpl = builderType.withImplSuffix()
         buildFile(type.packageName, "${type.simpleName}Dsl") {
-            addClass(builderType.simpleName) {
+            addImport("kotlin.contracts", "contract")
+            addAnnotation(ClassName("kotlin", "OptIn")) { addMember("%T::class", ExperimentalContracts::class) }
+            if (isSafe) {
+                addClass(builderType) {
+                    addModifiers(KModifier.SEALED)
+                    if (markerType != null && markerType != Annotation::class.asClassName()) addAnnotation(markerType)
+                    for (parameter in parameters) {
+                        if (parameter.hasNestedDsl) {
+                            if (parameter.collectionType != null) addParameterNestedAdder(parameter, builderType, true)
+                            else addParameterNestedSetter(parameter, builderType, true)
+                        }
+                        if (!parameter.isMandatory) addProperty(parameter.name, parameter.typeName.nullable) {
+                            mutable()
+                            addModifiers(KModifier.ABSTRACT)
+                            addKdoc(parameter, type)
+                        }
+                    }
+                    for (group in requiredGroups) addInterface(builderType.parameterInterface(group.first())) {
+                        addModifiers(KModifier.SEALED)
+                        if (markerType != null && markerType != Annotation::class.asClassName())
+                            addAnnotation(markerType)
+                        for (parameter in group) addProperty(parameter.name, parameter.typeName.nullable) {
+                            if (safe == SafetyType.Safe) mutable()
+                            addKdoc(parameter, type)
+                        }
+                    }
+                }
+
+                for (parameter in requiredParameters) addProperty(parameter.name, parameter.typeName) {
+                    mutable()
+                    receiver(builderType)
+                    addKdoc(parameter, type)
+                    getter {
+                        addAnnotation(Deprecated::class) {
+                            addMember("message = %S", "")
+                            addMember("level = %T.%L", DeprecationLevel::class, "HIDDEN")
+                        }
+                        addStatement("error(%S)", "Should not be called")
+                    }
+                    setter {
+                        addParameter("value", parameter.typeName)
+                        addReturnsContract(parameter.name, builderType.parameterInterface(parameter))
+                        addStatement("when (this) { is %T -> %L = value }", builderTypeImpl, parameter.name)
+                    }
+                }
+            }
+            addClass(if (isSafe) builderTypeImpl else builderType) {
+                if (isSafe) {
+                    superclass(builderType)
+                    for ((parameter) in requiredGroups) addSuperinterface(builderType.parameterInterface(parameter))
+                }
                 if (parameters.any { it.hasDefault }) {
                     for (i in bitFieldIndices) {
                         addProperty(DEFAULTS_BITFLAGS_FIELD_NAME + i, INT, KModifier.PRIVATE) {
@@ -85,23 +151,27 @@ class DslGenerator<A, T : A, C : A>(
                     }
                 }
                 for (parameter in parameters) {
-                    addParameterProperty(parameter, type)
+                    addParameterProperty(parameter, type, isSafe)
                     addParameterBuilderStyleSetter(parameter, builderType, type)
                     if (parameter.collectionType != null) {
                         addParameterBuilderStyleVarargSetter(parameter, builderType, type)
-                        if (parameter.hasNestedDsl) {
-                            addParameterNestedAdder(parameter)
+                        if (parameter.hasNestedDsl && !isSafe) {
+                            addParameterNestedAdder(parameter, builderType, false)
                         }
-                    } else if (parameter.hasNestedDsl) {
-                        addParameterNestedSetter(parameter)
+                    } else if (parameter.hasNestedDsl && !isSafe) {
+                        addParameterNestedSetter(parameter, builderType, false)
                     }
                 }
                 addFunction("build") {
                     returns(type)
-                    parameters.filter { it.isMandatory }.groupBy { it.group }.forEach { (_, parameters) ->
-                        addStatement("check(%L)·{ \"%L·must·be·assigned.\" }",
-                            parameters.map { "%L != null".codeFmt(it.name) }.joinToCode(" || "),
-                            parameters.joinToString(separator = ",·", prefix = if (parameters.size > 1) "One·of·" else "") { it.name }
+                    requiredGroups.forEach { group ->
+                        addStatement(
+                            "check(%L)·{ \"%L·must·be·assigned.\" }",
+                            group.map { "%L != null".codeFmt(it.name) }.joinToCode(" || "),
+                            group.joinToString(
+                                separator = ",·",
+                                prefix = if (group.size > 1) "One·of·" else ""
+                            ) { it.name }
                         )
                     }
                     if (parameters.any { it.hasDefault }) {
@@ -109,24 +179,31 @@ class DslGenerator<A, T : A, C : A>(
                             "return %T::class.java.getConstructor(%L, %L, %L).newInstance(%L, %L, null)",
                             type,
                             parameters.map {
-                                "%T::class.%L".codeFmt(it.typeName.toRawType().nonnull, if (it.typeName.isNullable) "javaObjectType" else "java")
+                                "%T::class.%L".codeFmt(
+                                    it.typeName.toRawType().nonnull,
+                                    if (it.typeName.isNullable) "javaObjectType" else "java"
+                                )
                             }.joinToCode(),
                             bitFieldIndices.map { "%T::class.java".codeFmt(INT) }.joinToCode(),
-                            if (kotlinVersion.isAtLeast(1, 5)) "%T::class.java".codeFmt(DefaultConstructorMarker::class.asClassName())
+                            if (kotlinVersion.isAtLeast(
+                                    1,
+                                    5
+                                )
+                            ) "%T::class.java".codeFmt(DefaultConstructorMarker::class.asClassName())
                             else "Class.forName(%S)".codeFmt(DefaultConstructorMarker::class.java.name),
                             parameters.map {
-                                    when {
-                                        it.typeName.isNullable -> "%L"
-                                        it.typeName == BOOLEAN -> "%L ?: false"
-                                        it.typeName == BYTE -> "%L ?: 0"
-                                        it.typeName == SHORT -> "%L ?: 0"
-                                        it.typeName == INT -> "%L ?: 0"
-                                        it.typeName == LONG -> "%L ?: 0"
-                                        it.typeName == CHAR -> "%L ?: '\\u0000'"
-                                        it.typeName == FLOAT -> "%L ?: 0.0f"
-                                        it.typeName == DOUBLE -> "%L ?: 0.0"
-                                        else -> "%L"
-                                    }.codeFmt(it.name)
+                                when {
+                                    it.typeName.isNullable -> "%L"
+                                    it.typeName == BOOLEAN -> "%L ?: false"
+                                    it.typeName == BYTE -> "%L ?: 0"
+                                    it.typeName == SHORT -> "%L ?: 0"
+                                    it.typeName == INT -> "%L ?: 0"
+                                    it.typeName == LONG -> "%L ?: 0"
+                                    it.typeName == CHAR -> "%L ?: '\\u0000'"
+                                    it.typeName == FLOAT -> "%L ?: 0.0f"
+                                    it.typeName == DOUBLE -> "%L ?: 0.0"
+                                    else -> "%L"
+                                }.codeFmt(it.name)
                             }.joinToCode(),
                             bitFieldIndices.map { "%L".codeFmt(DEFAULTS_BITFLAGS_FIELD_NAME + it) }.joinToCode()
                         )
@@ -134,7 +211,8 @@ class DslGenerator<A, T : A, C : A>(
                         addStatement(
                             "return %T(%L)",
                             type,
-                            parameters.map { (if (it.typeName.isNullable) "%L" else "%L!!").codeFmt(it.name) }.joinToCode()
+                            parameters.map { (if (it.typeName.isNullable) "%L" else "%L!!").codeFmt(it.name) }
+                                .joinToCode()
                         )
                     }
                 }
@@ -143,76 +221,135 @@ class DslGenerator<A, T : A, C : A>(
                     addAnnotation(markerType)
                 }
             }
-            addFunction(type.simpleName.replaceFirstChar { it.lowercase(Locale.getDefault()) }) {
-                addParameter("initializer", builderType.asLambdaReceiver())
-                addStatement("return %T().apply(initializer).build()", builderType)
+            addFunction(type.builderFunction) {
+                addModifiers(KModifier.INLINE)
+                addInitializerParameter(builderType, isSafe, parameters)
+                if (isSafe) addStatement(
+                    "return when(val builder = initializer(%T())) { is %T -> builder.build() }",
+                    builderTypeImpl,
+                    builderTypeImpl
+                ) else addStatement("return %T().apply(initializer).build()", builderType)
                 returns(type)
             }
         }.writeTo(clazz, codeGenerator)
         return true
     }
 
-    private fun TypeSpecBuilder.addParameterNestedSetter(parameter: Parameter) = addFunction(parameter.name) {
-        val nestedBuilderType = parameter.typeName.withBuilderSuffix()
-        addParameter("initializer", nestedBuilderType.asLambdaReceiver())
-        addStatement("val result = %T().apply(initializer).build()", nestedBuilderType)
+    private fun FunSpecBuilder.callBuilder(builderType: ClassName) = addStatement(
+        "val result = %L%L(initializer)",
+        builderType.packagePrefix,
+        builderType.builderFunction,
+    )
+
+    private fun TypeSpecBuilder.addParameterNestedSetter(
+        parameter: Parameter<T>,
+        builderType: ClassName,
+        isSafe: Boolean,
+    ): Unit = addFunction(parameter.name) {
+        addModifiers(KModifier.INLINE)
+        val parameterType = parameter.typeName.toRawType()
+        addInitializerParameter(parameterType.withBuilderSuffix(), isSafe, parameter.type?.parameters() ?: return)
+        if (isSafe && parameter.isMandatory) addReturnsContract(
+            builderType.simpleName,
+            builderType.parameterInterface(parameter)
+        )
+        callBuilder(parameterType)
         addStatement("%L = result", parameter.name)
         addStatement("return result")
         returns(parameter.typeName.nonnull)
     }
 
-    private fun TypeSpecBuilder.addParameterNestedAdder(parameter: Parameter) = addFunction(parameter.collectionType!!.singular) {
-        val elementType = (parameter.typeName as ParameterizedTypeName).typeArguments.first()
-        val nestedBuilderType = elementType.withBuilderSuffix()
-        addParameter("initializer", nestedBuilderType.asLambdaReceiver())
-        addStatement("val result = %T().apply(initializer).build()", nestedBuilderType)
-        addStatement("%1L = %1L?.plus(result) ?: %2L(result)", parameter.name, parameter.collectionType.createFunction)
+    private fun TypeSpecBuilder.addParameterNestedAdder(
+        parameter: Parameter<T>,
+        builderType: ClassName,
+        isSafe: Boolean,
+    ): Unit = addFunction(parameter.collectionType!!.singular) {
+        addModifiers(KModifier.INLINE)
+        val elementType = (parameter.typeName as ParameterizedTypeName).typeArguments.first().toRawType()
+        addInitializerParameter(elementType.withBuilderSuffix(), isSafe, parameter.type?.parameters() ?: return)
+        if (isSafe && parameter.isMandatory) addReturnsContract(
+            builderType.simpleName,
+            builderType.parameterInterface(parameter)
+        )
+        callBuilder(elementType)
+        val assignment = CodeBlock.of(
+            "%1L = %1L?.plus(result) ?: %2L(result)",
+            parameter.name,
+            parameter.collectionType.createFunction
+        )
+        if (isSafe) addStatement("when (this) { is %T -> %L }", builderType.withImplSuffix(), assignment)
+        else addStatement("%L", assignment)
         addStatement("return result")
         returns(elementType.nonnull)
     }
 
-    private fun TypeSpecBuilder.addParameterBuilderStyleVarargSetter(parameter: Parameter, builderType: ClassName, type: ClassName) =
-        addFunction("with${parameter.name.replaceFirstChar { it.uppercase() }}") {
-            val elementType =
-                (parameter.typeName as ParameterizedTypeName).typeArguments.first().let { if (it is WildcardTypeName) it.outTypes.first() else it }
-            returns(builderType)
-            addParameter(parameter.name, elementType, KModifier.VARARG)
-            addStatement("this.%1L·= %1L.%2L()", parameter.name, parameter.collectionType!!.convertFunction)
-            addStatement("return this")
-            parameter.doc?.let { addKdoc(it) }
-            addKdoc("@see %T.%L", type, parameter.name)
-        }
+    private fun FunSpecBuilder.addReturnsContract(thisLabel: String, castAs: TypeName) =
+        addStatement("contract { returns() implies (this@%L is %T) }", thisLabel, castAs)
 
-    private fun TypeSpecBuilder.addParameterBuilderStyleSetter(parameter: Parameter, builderType: ClassName, type: ClassName) =
-        addFunction("with${parameter.name.replaceFirstChar { it.uppercase() }}") {
-            returns(builderType)
-            addParameter(parameter.name, parameter.typeName)
-            addStatement("this.%1L·= %1L", parameter.name)
-            addStatement("return this")
-            parameter.doc?.let { addKdoc(it) }
-            addKdoc("@see %T.%L", type, parameter.name)
-        }
-
-    private fun TypeSpecBuilder.addParameterProperty(parameter: Parameter, type: ClassName) = addProperty(parameter.name, parameter.typeName.nullable) {
-        mutable(true)
-        if (parameter.hasDefault) {
-            delegate(
-                "%1T.observable(null)·{·_, _, _·-> %2L·= %2L and %3L }",
-                Delegates::class.asClassName(),
-                DEFAULTS_BITFLAGS_FIELD_NAME + (parameter.index / 32),
-                (1 shl parameter.index % 32).inv()
-            )
-        } else {
-            initializer("null")
-        }
-        if (parameter.isMandatory) {
-            addAnnotation(DslMandatory::class) {
-                useSiteTarget(AnnotationSpec.UseSiteTarget.SET)
-                addMember("group = %S", parameter.group)
-            }
-        }
+    private fun Documentable.Builder<*>.addKdoc(parameter: Parameter<T>, type: ClassName) {
         parameter.doc?.let { addKdoc(it) }
         addKdoc("@see %T.%L", type, parameter.name)
     }
+
+    private fun FunSpecBuilder.addInitializerParameter(
+        builderType: ClassName,
+        isSafe: Boolean,
+        parameters: List<Parameter<T>>,
+    ) = if (isSafe) {
+        val type = TypeVariableName("T", parameters.filter { it.isMandatory }.distinctBy { it.group }.map {
+            builderType.parameterInterface(it)
+        }.ifEmpty { listOf(builderType) })
+        addTypeVariable(type)
+        addParameter("initializer", LambdaTypeName.get(receiver = builderType, returnType = type))
+    } else addParameter("initializer", builderType.asLambdaReceiver())
+
+    private fun TypeSpecBuilder.addParameterBuilderStyleVarargSetter(
+        parameter: Parameter<T>,
+        builderType: ClassName,
+        type: ClassName
+    ) = addFunction("with${parameter.name.replaceFirstChar { it.uppercase() }}") {
+        val elementType = (parameter.typeName as ParameterizedTypeName).typeArguments.first()
+            .let { if (it is WildcardTypeName) it.outTypes.first() else it }
+        returns(builderType)
+        addParameter(parameter.name, elementType, KModifier.VARARG)
+        addStatement("this.%1L·= %1L.%2L()", parameter.name, parameter.collectionType!!.convertFunction)
+        addStatement("return this")
+        addKdoc(parameter, type)
+    }
+
+    private fun TypeSpecBuilder.addParameterBuilderStyleSetter(
+        parameter: Parameter<T>,
+        builderType: ClassName,
+        type: ClassName
+    ) = addFunction("with${parameter.name.replaceFirstChar { it.uppercase() }}") {
+        returns(builderType)
+        addParameter(parameter.name, parameter.typeName)
+        addStatement("this.%1L·= %1L", parameter.name)
+        addStatement("return this")
+        addKdoc(parameter, type)
+    }
+
+    private fun TypeSpecBuilder.addParameterProperty(parameter: Parameter<T>, type: ClassName, isSafe: Boolean) =
+        addProperty(parameter.name, parameter.typeName.nullable) {
+            mutable(true)
+            if (parameter.hasDefault) {
+                delegate(
+                    "%1T.observable(null)·{·_, _, _·-> %2L·= %2L and %3L }",
+                    Delegates::class.asClassName(),
+                    DEFAULTS_BITFLAGS_FIELD_NAME + (parameter.index / 32),
+                    (1 shl parameter.index % 32).inv()
+                )
+            } else {
+                initializer("null")
+            }
+            if (parameter.isMandatory) {
+                addAnnotation(DslMandatory::class) {
+                    useSiteTarget(AnnotationSpec.UseSiteTarget.SET)
+                    addMember("group = %S", parameter.group)
+                }
+            }
+            if (isSafe) addModifiers(KModifier.OVERRIDE)
+            addKdoc(parameter, type)
+        }
 
 }

--- a/processor/src/main/kotlin/com/faendir/kotlin/autodsl/kapt/KaptSourceInfoResolver.kt
+++ b/processor/src/main/kotlin/com/faendir/kotlin/autodsl/kapt/KaptSourceInfoResolver.kt
@@ -143,6 +143,10 @@ class Type(internal val element: TypeElement, internal val typeSpec: TypeSpec) :
     override fun toString(): String {
         return element.toString()
     }
+
+    override fun equals(other: Any?) = this === other || (other is Type && this.element == other.element)
+
+    override fun hashCode() = element.hashCode()
 }
 
 class Constructor(internal val element: ExecutableElement, internal val constructorSpec: FunSpec, internal val isPrimary: Boolean) : Annotated {

--- a/processor/src/main/kotlin/com/faendir/kotlin/autodsl/kotlinpoetutils.kt
+++ b/processor/src/main/kotlin/com/faendir/kotlin/autodsl/kotlinpoetutils.kt
@@ -7,6 +7,7 @@ import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.WildcardTypeName
 import com.squareup.kotlinpoet.asClassName
+import java.util.Locale
 
 @Suppress("UNCHECKED_CAST")
 val <T : TypeName> T.nonnull: T
@@ -44,8 +45,14 @@ fun TypeName.withoutAnnotations(): TypeName = when (this) {
     else -> this
 }
 
-fun ClassName.withBuilderSuffix() = ClassName(packageName, "${simpleName}Builder")
+fun ClassName.withBuilderSuffix() = withSuffix("Builder")
 
-fun TypeName.withBuilderSuffix() = toRawType().withBuilderSuffix()
+fun ClassName.withImplSuffix() = withSuffix("Impl")
+
+private fun ClassName.withSuffix(suffix: String) = ClassName(packageName, "$simpleName$suffix")
 
 fun TypeName.asLambdaReceiver() = LambdaTypeName.get(receiver = this, returnType = Unit::class.asClassName())
+
+val ClassName.packagePrefix get() = if (packageName.isEmpty()) "" else "$packageName."
+
+val ClassName.builderFunction get() = simpleName.replaceFirstChar { it.lowercase(Locale.getDefault()) }

--- a/processor/src/main/kotlin/com/faendir/kotlin/autodsl/parameter/Parameter.kt
+++ b/processor/src/main/kotlin/com/faendir/kotlin/autodsl/parameter/Parameter.kt
@@ -2,18 +2,19 @@ package com.faendir.kotlin.autodsl.parameter
 
 import com.squareup.kotlinpoet.TypeName
 
-class Parameter(
+class Parameter<T>(
     val typeName: TypeName,
     val name: String,
     val doc: String?,
     val hasDefault: Boolean,
     requiredGroup: String?,
     val index: Int,
-    val hasNestedDsl: Boolean,
-    val collectionType: CollectionType?
+    val type: T?,
+    val collectionType: CollectionType?,
 ) {
     val isMandatory = requiredGroup != null || !hasDefault && !typeName.isNullable
     val group = requiredGroup ?: (name + index)
+    val hasNestedDsl = type != null
 }
 
 sealed class CollectionType(val createFunction: String, val convertFunction: String, val singular: String) {

--- a/processor/src/main/kotlin/com/faendir/kotlin/autodsl/parameter/ParameterFactory.kt
+++ b/processor/src/main/kotlin/com/faendir/kotlin/autodsl/parameter/ParameterFactory.kt
@@ -5,39 +5,47 @@ import com.shadow.pluralize.utils.Plurality
 import com.faendir.kotlin.autodsl.*
 import com.faendir.kotlin.autodsl.parameter.CollectionType.ListType
 import com.faendir.kotlin.autodsl.parameter.CollectionType.SetType
+import com.google.devtools.ksp.symbol.ClassKind
 import com.squareup.kotlinpoet.asClassName
-import kotlin.reflect.KClass
 
 class ParameterFactory<A, T : A, C : A, P : A>(private val resolver: SourceInfoResolver<A, T, C, P>) {
+    private val classes: Set<T> = resolver.run {
+        getClassesWithAnnotation(AutoDsl::class).flatMapTo(mutableSetOf()) {
+            when (it.getClassKind()) {
+                ClassKind.ANNOTATION_CLASS -> getClassesWithAnnotation(it)
+                else -> listOf(it)
+            }
+        }
+    }
     private val set = Set::class.asClassName()
     private val list = List::class.asClassName()
     private val collection = Collection::class.asClassName()
     private val iterable = Iterable::class.asClassName()
 
-    fun getParameters(constructor: C): List<Parameter> = resolver.run {
-        return constructor.getParameters().withIndex().map { (index, parameter) ->
-            val type = parameter.getTypeName()
-            val rawType = type.toRawType()
-            val (hasNestedDsl, collectionType) = when (rawType) {
-                set -> parameter.hasAnnotatedTypeArgument(AutoDsl::class) to SetType(findSingular(parameter, index))
-                list, collection, iterable -> parameter.hasAnnotatedTypeArgument(AutoDsl::class) to ListType(findSingular(parameter, index))
-                else -> (parameter.getTypeDeclaration()?.hasAnnotation(AutoDsl::class) == true) to null
+    fun getParameters(constructor: C): List<Parameter<T>> = resolver.run {
+        constructor.getParameters().mapIndexed { index, parameter ->
+            val typeName = parameter.getTypeName()
+            val rawType = typeName.toRawType()
+            val (type, collectionType) = when (rawType) {
+                set -> parameter.typeArgumentIfAnnotated() to SetType(findSingular(parameter, index))
+                list, collection, iterable -> parameter.typeArgumentIfAnnotated() to ListType(findSingular(parameter, index))
+                else -> (parameter.getTypeDeclaration()?.takeIf { it in classes }) to null
             }
             Parameter(
-                type,
+                typeName,
                 parameter.getName(),
                 parameter.getDoc(),
                 parameter.hasDefault(),
                 parameter.getAnnotationProperty(AutoDslRequired::class, AutoDslRequired::group),
                 index,
-                hasNestedDsl,
-                collectionType
+                type,
+                collectionType,
             )
         }
     }
 
-    private fun P.hasAnnotatedTypeArgument(annotation: KClass<out Annotation>): Boolean = resolver.run {
-        return getTypeArguments().firstOrNull()?.hasAnnotation(annotation) ?: false
+    private fun P.typeArgumentIfAnnotated(): T? = resolver.run {
+        getTypeArguments().firstOrNull()?.takeIf { it in classes }
     }
 
     private fun findSingular(parameter: P, index: Int): String = resolver.run {

--- a/processor/src/test/kotlin/com/faendir/kotlin/autodsl/BasicTest.kt
+++ b/processor/src/test/kotlin/com/faendir/kotlin/autodsl/BasicTest.kt
@@ -8,7 +8,7 @@ class BasicTest {
     fun `basic values`() = compile(
         """
                 import com.faendir.kotlin.autodsl.AutoDsl
-                @AutoDsl
+                @AutoDsl($SAFETY)
                 class Entity(val a: String)
             """,
         """
@@ -16,7 +16,7 @@ class BasicTest {
                 import strikt.assertions.isEqualTo
                 fun test() {
                     expectThat(entity {
-                        a = "Hi"
+                        a = "Hi"$RETURN_SAFE
                     }.a).isEqualTo("Hi")
                 }
             """
@@ -26,7 +26,7 @@ class BasicTest {
     fun `primitive values`() = compile(
         """
                 import com.faendir.kotlin.autodsl.AutoDsl
-                @AutoDsl
+                @AutoDsl($SAFETY)
                 class Entity(
                     val a: Boolean, 
                     val b: Byte,
@@ -49,7 +49,7 @@ class BasicTest {
                         e = 4L
                         f = 'X'
                         g = 5.0f
-                        h = 6.0
+                        h = 6.0$RETURN_SAFE
                     }){
                         get(Entity::a).isEqualTo(true)
                         get(Entity::b).isEqualTo(1)
@@ -69,16 +69,16 @@ class BasicTest {
         """
                 package com.faendir.test
                 import com.faendir.kotlin.autodsl.AutoDsl
-                @AutoDsl
+                @AutoDsl($SAFETY)
                 class Entity(val a: String)
             """,
         """
                 import strikt.api.expectThat
                 import strikt.assertions.isEqualTo
-                import com.faendir.test.entity
+                import com.faendir.test.*
                 fun test() {
                     expectThat(entity {
-                        a = "Hi"
+                        a = "Hi"$RETURN_SAFE
                     }.a).isEqualTo("Hi")
                 }
             """
@@ -89,7 +89,7 @@ class BasicTest {
         """
                 package com.faendir.test
                 import com.faendir.kotlin.autodsl.AutoDsl
-                @AutoDsl
+                @AutoDsl($SAFETY)
                 class Entity {
                     val a: String
                     constructor(a: String) {
@@ -100,10 +100,10 @@ class BasicTest {
         """
                 import strikt.api.expectThat
                 import strikt.assertions.isEqualTo
-                import com.faendir.test.entity
+                import com.faendir.test.*
                 fun test() {
                     expectThat(entity {
-                        a = "Hi"
+                        a = "Hi"$RETURN_SAFE
                     }.a).isEqualTo("Hi")
                 }
             """

--- a/processor/src/test/kotlin/com/faendir/kotlin/autodsl/DefaultValuesTest.kt
+++ b/processor/src/test/kotlin/com/faendir/kotlin/autodsl/DefaultValuesTest.kt
@@ -8,14 +8,14 @@ class DefaultValuesTest {
     fun `default value`() = compile(
         """
                 import com.faendir.kotlin.autodsl.AutoDsl
-                @AutoDsl
+                @AutoDsl($SAFETY)
                 class Entity(val a: String = "Hi")
             """,
         """
                 import strikt.api.expectThat
                 import strikt.assertions.isEqualTo
                 fun test() {
-                    expectThat(entity {}.a).isEqualTo("Hi")
+                    expectThat(entity {$RETURN_SAFE}.a).isEqualTo("Hi")
                 }
             """
     )
@@ -24,7 +24,7 @@ class DefaultValuesTest {
     fun `primitive default value`() = compile(
         """
                 import com.faendir.kotlin.autodsl.AutoDsl
-                @AutoDsl
+                @AutoDsl($SAFETY)
                 class Entity(
                     val a: Boolean = true, 
                     val b: Byte = 1,
@@ -39,7 +39,7 @@ class DefaultValuesTest {
                 import strikt.api.expectThat
                 import strikt.assertions.isEqualTo
                 fun test() {
-                    expectThat(entity {}){
+                    expectThat(entity {$RETURN_SAFE}){
                         get(Entity::a).isEqualTo(true)
                         get(Entity::b).isEqualTo(1)
                         get(Entity::c).isEqualTo(2)
@@ -57,7 +57,7 @@ class DefaultValuesTest {
     fun `nullable primitive values with default value present`() = compile(
         """
                 import com.faendir.kotlin.autodsl.AutoDsl
-                @AutoDsl
+                @AutoDsl($SAFETY)
                 class Entity(
                     val a: Boolean?, 
                     val b: Byte?,
@@ -81,7 +81,7 @@ class DefaultValuesTest {
                         e = 4L
                         f = 'X'
                         g = 5.0f
-                        h = 6.0
+                        h = 6.0$RETURN_SAFE
                     }){
                         get(Entity::a).isEqualTo(true)
                         get(Entity::b).isEqualTo(1)
@@ -101,7 +101,7 @@ class DefaultValuesTest {
     fun `default value after required`() = compile(
         """
                 import com.faendir.kotlin.autodsl.AutoDsl
-                @AutoDsl
+                @AutoDsl($SAFETY)
                 class Entity(val a: String, val b: String = "Hi")
             """,
         """
@@ -109,7 +109,7 @@ class DefaultValuesTest {
                 import strikt.assertions.isEqualTo
                 fun test() {
                     expectThat(entity {
-                        a = "a"
+                        a = "a"$RETURN_SAFE
                     }.b).isEqualTo("Hi")
                 }
             """
@@ -119,7 +119,7 @@ class DefaultValuesTest {
     fun `default value before required`() = compile(
         """
                 import com.faendir.kotlin.autodsl.AutoDsl
-                @AutoDsl
+                @AutoDsl($SAFETY)
                 class Entity(val a: String = "Hi", val b: String)
             """,
         """
@@ -127,7 +127,7 @@ class DefaultValuesTest {
                 import strikt.assertions.isEqualTo
                 fun test() {
                     expectThat(entity {
-                        b = "b"
+                        b = "b"$RETURN_SAFE
                     }.a).isEqualTo("Hi")
                 }
             """
@@ -137,7 +137,7 @@ class DefaultValuesTest {
     fun `default values with over 32 parameters`() = compile(
     """
                 import com.faendir.kotlin.autodsl.AutoDsl
-                @AutoDsl
+                @AutoDsl($SAFETY)
                 class Entity(
                     val a1: String = "a1",
                     val a2: String = "a2",
@@ -178,7 +178,7 @@ class DefaultValuesTest {
                 import strikt.api.expectThat
                 import strikt.assertions.isEqualTo
                 fun test() {
-                    val entity = entity {}
+                    val entity = entity {$RETURN_SAFE}
                     expectThat(entity.a1).isEqualTo("a1")
                     expectThat(entity.a2).isEqualTo("a2")
                     expectThat(entity.a3).isEqualTo("a3")

--- a/processor/src/test/kotlin/com/faendir/kotlin/autodsl/FailTest.kt
+++ b/processor/src/test/kotlin/com/faendir/kotlin/autodsl/FailTest.kt
@@ -9,7 +9,7 @@ class FailTest {
     fun `interface`() = compile(
         """
                 import com.faendir.kotlin.autodsl.AutoDsl
-                @AutoDsl
+                @AutoDsl($SAFETY)
                 interface Entity
             """,
         expect = COMPILATION_ERROR
@@ -19,7 +19,7 @@ class FailTest {
     fun `enum class`() = compile(
         """
                 import com.faendir.kotlin.autodsl.AutoDsl
-                @AutoDsl
+                @AutoDsl($SAFETY)
                 enum class Entity { A, B, X }
             """,
         expect = COMPILATION_ERROR
@@ -29,7 +29,7 @@ class FailTest {
     fun `object`() = compile(
         """
                 import com.faendir.kotlin.autodsl.AutoDsl
-                @AutoDsl
+                @AutoDsl($SAFETY)
                 object Entity
             """,
         expect = COMPILATION_ERROR
@@ -39,7 +39,7 @@ class FailTest {
     fun `abstract class`() = compile(
         """
                 import com.faendir.kotlin.autodsl.AutoDsl
-                @AutoDsl
+                @AutoDsl($SAFETY)
                 abstract class Entity
             """,
         expect = COMPILATION_ERROR
@@ -49,7 +49,7 @@ class FailTest {
     fun `private constructor`() = compile(
         """
                 import com.faendir.kotlin.autodsl.AutoDsl
-                @AutoDsl
+                @AutoDsl($SAFETY)
                 class Entity private constructor()
             """,
         expect = COMPILATION_ERROR

--- a/processor/src/test/kotlin/com/faendir/kotlin/autodsl/GenericTest.kt
+++ b/processor/src/test/kotlin/com/faendir/kotlin/autodsl/GenericTest.kt
@@ -8,7 +8,7 @@ class GenericTest {
     fun `star projection`() = compile(
         """
                 import com.faendir.kotlin.autodsl.AutoDsl
-                @AutoDsl
+                @AutoDsl($SAFETY)
                 class Entity(val a: List<*>)
             """,
         """
@@ -16,7 +16,7 @@ class GenericTest {
                 import strikt.assertions.isEqualTo
                 fun test() {
                     expectThat(entity {
-                        a = listOf("Hi")
+                        a = listOf("Hi")$RETURN_SAFE
                     }.a).isEqualTo(listOf("Hi"))
                 }
             """
@@ -26,7 +26,7 @@ class GenericTest {
     fun invariant() = compile(
         """
                 import com.faendir.kotlin.autodsl.AutoDsl
-                @AutoDsl
+                @AutoDsl($SAFETY)
                 class Entity(val a: List<Any>)
             """,
         """
@@ -34,7 +34,7 @@ class GenericTest {
                 import strikt.assertions.isEqualTo
                 fun test() {
                     expectThat(entity {
-                        a = listOf("Hi")
+                        a = listOf("Hi")$RETURN_SAFE
                     }.a).isEqualTo(listOf("Hi"))
                 }
             """
@@ -44,7 +44,7 @@ class GenericTest {
     fun `out projection`() = compile(
         """
                 import com.faendir.kotlin.autodsl.AutoDsl
-                @AutoDsl
+                @AutoDsl($SAFETY)
                 class Entity(val a: List<out Any>)
             """,
         """
@@ -52,7 +52,7 @@ class GenericTest {
                 import strikt.assertions.isEqualTo
                 fun test() {
                     expectThat(entity {
-                        a = listOf("Hi")
+                        a = listOf("Hi")$RETURN_SAFE
                     }.a).isEqualTo(listOf("Hi"))
                 }
             """
@@ -62,7 +62,7 @@ class GenericTest {
     fun `in projection`() = compile(
         """
                 import com.faendir.kotlin.autodsl.AutoDsl
-                @AutoDsl
+                @AutoDsl($SAFETY)
                 class Entity(val a: Class<in String>)
             """,
         """
@@ -70,7 +70,7 @@ class GenericTest {
                 import strikt.assertions.isEqualTo
                 fun test() {
                     expectThat(entity {
-                        a = String::class.java
+                        a = String::class.java$RETURN_SAFE
                     }.a).isEqualTo(String::class.java)
                 }
             """
@@ -80,7 +80,7 @@ class GenericTest {
     fun `java type`() = compile(
         """
                 import com.faendir.kotlin.autodsl.AutoDsl
-                @AutoDsl
+                @AutoDsl($SAFETY)
                 class Entity(val a: List<Class<*>>)
             """,
         """
@@ -88,7 +88,7 @@ class GenericTest {
                 import strikt.assertions.isEqualTo
                 fun test() {
                     expectThat(entity {
-                        a = listOf(String::class.java)
+                        a = listOf(String::class.java)$RETURN_SAFE
                     }.a).isEqualTo(listOf(String::class.java))
                 }
             """

--- a/processor/src/test/kotlin/com/faendir/kotlin/autodsl/LambdaTest.kt
+++ b/processor/src/test/kotlin/com/faendir/kotlin/autodsl/LambdaTest.kt
@@ -8,7 +8,7 @@ class LambdaTest {
     fun `simple lambda`() = compile(
         """
                 import com.faendir.kotlin.autodsl.AutoDsl
-                @AutoDsl
+                @AutoDsl($SAFETY)
                 class Entity(val a: () -> String)
             """,
         """
@@ -16,7 +16,7 @@ class LambdaTest {
                 import strikt.assertions.isEqualTo
                 fun test() {
                     expectThat(entity {
-                        a = {"Hi"}
+                        a = {"Hi"}$RETURN_SAFE
                     }.a()).isEqualTo("Hi")
                 }
             """
@@ -26,7 +26,7 @@ class LambdaTest {
     fun `lambda with parameter`() = compile(
         """
                 import com.faendir.kotlin.autodsl.AutoDsl
-                @AutoDsl
+                @AutoDsl($SAFETY)
                 class Entity(val a: (name: String) -> String)
             """,
         """
@@ -34,7 +34,7 @@ class LambdaTest {
                 import strikt.assertions.isEqualTo
                 fun test() {
                     expectThat(entity {
-                        a = { "Hi ${'$'}it" }
+                        a = { "Hi ${'$'}it" }$RETURN_SAFE
                     }.a("F43nd1r")).isEqualTo("Hi F43nd1r")
                 }
             """
@@ -44,7 +44,7 @@ class LambdaTest {
     fun `lambda with receiver`() = compile(
         """
                 import com.faendir.kotlin.autodsl.AutoDsl
-                @AutoDsl
+                @AutoDsl($SAFETY)
                 class Entity(val a: String.() -> String)
             """,
         """
@@ -52,7 +52,7 @@ class LambdaTest {
                 import strikt.assertions.isEqualTo
                 fun test() {
                     expectThat(entity {
-                        a = { "Hi ${'$'}this" }
+                        a = { "Hi ${'$'}this" }$RETURN_SAFE
                     }.a("F43nd1r")).isEqualTo("Hi F43nd1r")
                 }
             """
@@ -62,14 +62,14 @@ class LambdaTest {
     fun `lambda with default value`() = compile(
         """
                 import com.faendir.kotlin.autodsl.AutoDsl
-                @AutoDsl
+                @AutoDsl($SAFETY)
                 class Entity(val a: (name: String) -> String = { "Hi ${'$'}it" })
             """,
         """
                 import strikt.api.expectThat
                 import strikt.assertions.isEqualTo
                 fun test() {
-                    expectThat(entity {}.a("F43nd1r")).isEqualTo("Hi F43nd1r")
+                    expectThat(entity {$RETURN_SAFE}.a("F43nd1r")).isEqualTo("Hi F43nd1r")
                 }
             """
     )
@@ -78,14 +78,14 @@ class LambdaTest {
     fun `lambda with receiver and default value`() = compile(
         """
                 import com.faendir.kotlin.autodsl.AutoDsl
-                @AutoDsl
+                @AutoDsl($SAFETY)
                 class Entity(val a: String.() -> String = { "Hi ${'$'}this" })
             """,
         """
                 import strikt.api.expectThat
                 import strikt.assertions.isEqualTo
                 fun test() {
-                    expectThat(entity {}.a("F43nd1r")).isEqualTo("Hi F43nd1r")
+                    expectThat(entity {$RETURN_SAFE}.a("F43nd1r")).isEqualTo("Hi F43nd1r")
                 }
             """
     )

--- a/processor/src/test/kotlin/com/faendir/kotlin/autodsl/MarkerTest.kt
+++ b/processor/src/test/kotlin/com/faendir/kotlin/autodsl/MarkerTest.kt
@@ -11,7 +11,7 @@ class MarkerTest {
 
                 annotation class MyDslMarker
 
-                @AutoDsl(MyDslMarker::class)
+                @AutoDsl(MyDslMarker::class, $SAFETY)
                 class Entity(val a: String)
             """,
         """
@@ -21,7 +21,7 @@ class MarkerTest {
                 fun test() {
                     expectThat(EntityBuilder::class.java).get { getAnnotation(MyDslMarker::class.java) }.isNotNull()
                     expectThat(entity {
-                        a = "Hi"
+                        a = "Hi"$RETURN_SAFE
                     }.a).isEqualTo("Hi")
                 }
             """
@@ -33,7 +33,7 @@ class MarkerTest {
                 import com.faendir.kotlin.autodsl.AutoDsl
                 import org.junit.jupiter.api.Disabled
 
-                @AutoDsl(Disabled::class)
+                @AutoDsl(Disabled::class, $SAFETY)
                 class Entity(val a: String)
             """,
         """
@@ -45,7 +45,7 @@ class MarkerTest {
                 fun test() {
                     expectThat(EntityBuilder::class.java).get { getAnnotation(Disabled::class.java) }.isNotNull()
                     expectThat(entity {
-                        a = "Hi"
+                        a = "Hi"$RETURN_SAFE
                     }.a).isEqualTo("Hi")
                 }
             """

--- a/processor/src/test/kotlin/com/faendir/kotlin/autodsl/MetaAnnotationTest.kt
+++ b/processor/src/test/kotlin/com/faendir/kotlin/autodsl/MetaAnnotationTest.kt
@@ -8,7 +8,7 @@ class MetaAnnotationTest {
     fun `meta annotation`() = compile(
         """
                 import com.faendir.kotlin.autodsl.AutoDsl
-                @AutoDsl
+                @AutoDsl($SAFETY)
                 annotation class MyAutoDsl
 
                 @MyAutoDsl
@@ -19,7 +19,7 @@ class MetaAnnotationTest {
                 import strikt.assertions.isEqualTo
                 fun test() {
                     expectThat(entity {
-                        a = "Hi"
+                        a = "Hi"$RETURN_SAFE
                     }.a).isEqualTo("Hi")
                 }
             """
@@ -32,7 +32,7 @@ class MetaAnnotationTest {
 
                 annotation class MyDslMarker
 
-                @AutoDsl(MyDslMarker::class)
+                @AutoDsl(MyDslMarker::class, $SAFETY)
                 annotation class MyAutoDsl
 
                 @MyAutoDsl
@@ -45,7 +45,7 @@ class MetaAnnotationTest {
                 fun test() {
                     expectThat(EntityBuilder::class.java).get { getAnnotation(MyDslMarker::class.java) }.isNotNull()
                     expectThat(entity {
-                        a = "Hi"
+                        a = "Hi"$RETURN_SAFE
                     }.a).isEqualTo("Hi")
                 }
             """

--- a/processor/src/test/kotlin/com/faendir/kotlin/autodsl/NestedClassTest.kt
+++ b/processor/src/test/kotlin/com/faendir/kotlin/autodsl/NestedClassTest.kt
@@ -9,7 +9,7 @@ class NestedClassTest {
         """
                 import com.faendir.kotlin.autodsl.AutoDsl
                 class Outer {
-                    @AutoDsl
+                    @AutoDsl($SAFETY)
                     class Entity(val a: String)
                 }
             """,
@@ -18,7 +18,7 @@ class NestedClassTest {
                 import strikt.assertions.isEqualTo
                 fun test() {
                     expectThat(entity {
-                        a = "Hi"
+                        a = "Hi"$RETURN_SAFE
                     }.a).isEqualTo("Hi")
                 }
             """
@@ -28,7 +28,7 @@ class NestedClassTest {
     fun `nested class as value`() = compile(
         """
                 import com.faendir.kotlin.autodsl.AutoDsl
-                @AutoDsl
+                @AutoDsl($SAFETY)
                 class Entity(val a: A) {
                     data class A(val a: String)
                 }
@@ -38,7 +38,7 @@ class NestedClassTest {
                 import strikt.assertions.isEqualTo
                 fun test() {
                     expectThat(entity {
-                        a = Entity.A("Hi")
+                        a = Entity.A("Hi")$RETURN_SAFE
                     }){
                         get(Entity::a).isEqualTo(Entity.A("Hi"))
                     }

--- a/processor/src/test/kotlin/com/faendir/kotlin/autodsl/NestingTest.kt
+++ b/processor/src/test/kotlin/com/faendir/kotlin/autodsl/NestingTest.kt
@@ -7,9 +7,9 @@ class NestingTest {
     fun `basic nesting`() = compile(
         """
                 import com.faendir.kotlin.autodsl.AutoDsl
-                @AutoDsl
+                @AutoDsl($SAFETY)
                 class Entity(val a: Entity2)
-                @AutoDsl
+                @AutoDsl($SAFETY)
                 class Entity2(val b: String)
             """,
         """
@@ -18,8 +18,8 @@ class NestingTest {
                 fun test() {
                     expectThat(entity {
                         a {
-                            b = "Hi"
-                        }
+                            b = "Hi"$RETURN_SAFE
+                        }$RETURN_SAFE
                     }.a.b).isEqualTo("Hi")
                 }
             """
@@ -29,11 +29,11 @@ class NestingTest {
     fun `deep nesting`() = compile(
         """
                 import com.faendir.kotlin.autodsl.AutoDsl
-                @AutoDsl
+                @AutoDsl($SAFETY)
                 class Entity(val a: Entity2)
-                @AutoDsl
+                @AutoDsl($SAFETY)
                 class Entity2(val b: Entity3)
-                @AutoDsl
+                @AutoDsl($SAFETY)
                 class Entity3(val c: String)
             """,
         """
@@ -43,9 +43,9 @@ class NestingTest {
                     expectThat(entity {
                         a {
                             b {
-                                c = "Hi"
-                            }
-                        }
+                                c = "Hi"$RETURN_SAFE
+                            }$RETURN_SAFE
+                        }$RETURN_SAFE
                     }.a.b.c).isEqualTo("Hi")
                 }
             """
@@ -55,9 +55,9 @@ class NestingTest {
     fun `collection nesting`() = compile(
         """
                 import com.faendir.kotlin.autodsl.AutoDsl
-                @AutoDsl
+                @AutoDsl($SAFETY)
                 class Entity(val a: List<Entity2>, val b: Collection<Entity2>, val c: Set<Entity2>)
-                @AutoDsl
+                @AutoDsl($SAFETY)
                 data class Entity2(val d: String)
             """,
         """
@@ -67,17 +67,17 @@ class NestingTest {
                 fun test() {
                     expectThat(entity {
                         a {
-                            d = "a"
+                            d = "a"$RETURN_SAFE
                         }
                         a {
-                            d = "a2"
+                            d = "a2"$RETURN_SAFE
                         }
                         b {
-                            d = "b"
+                            d = "b"$RETURN_SAFE
                         }
                         c {
-                            d = "c"
-                        }
+                            d = "c"$RETURN_SAFE
+                        }$RETURN_SAFE
                     }){
                         with(Entity::a) {
                             isA<List<Entity2>>()
@@ -100,31 +100,31 @@ class NestingTest {
     fun `automatic singularization`() = compile(
         """
                 import com.faendir.kotlin.autodsl.AutoDsl
-                @AutoDsl
+                @AutoDsl($SAFETY)
                 class Entity(
                     val friends: List<Entity2>, 
                     val men: List<Entity2>, 
                     val lives: List<Entity2>, 
                     val camelCasedNames: List<Entity2>
                 )
-                @AutoDsl
+                @AutoDsl($SAFETY)
                 data class Entity2(val a: String)
             """,
         """
                 fun test() {
                     entity {
                         friend {
-                            a = "a"
+                            a = "a"$RETURN_SAFE
                         }
                         man {
-                            a = "b"
+                            a = "b"$RETURN_SAFE
                         }
                         life {
-                            a = "c"
+                            a = "c"$RETURN_SAFE
                         }
                         camelCasedName {
-                            a = "d"
-                        }
+                            a = "d"$RETURN_SAFE
+                        }$RETURN_SAFE
                     }
                 }
             """
@@ -135,17 +135,17 @@ class NestingTest {
         """
                 import com.faendir.kotlin.autodsl.AutoDsl
                 import com.faendir.kotlin.autodsl.AutoDslSingular
-                @AutoDsl
+                @AutoDsl($SAFETY)
                 class Entity(@AutoDslSingular("clazz") val classes: List<Entity2>)
-                @AutoDsl
+                @AutoDsl($SAFETY)
                 data class Entity2(val a: String)
             """,
         """
                 fun test() {
                     entity {
                         clazz {
-                            a = "a"
-                        }
+                            a = "a"$RETURN_SAFE
+                        }$RETURN_SAFE
                     }
                 }
             """

--- a/sample-kapt/src/main/kotlin/com/faendir/kotlin/autodsl/sample/safe/Person.kt
+++ b/sample-kapt/src/main/kotlin/com/faendir/kotlin/autodsl/sample/safe/Person.kt
@@ -1,0 +1,50 @@
+package com.faendir.kotlin.autodsl.sample.safe
+
+import com.faendir.kotlin.autodsl.AutoDsl
+import com.faendir.kotlin.autodsl.AutoDslConstructor
+import com.faendir.kotlin.autodsl.AutoDslRequired
+import com.faendir.kotlin.autodsl.SafetyType
+
+@DslMarker
+annotation class MyDsl
+
+@AutoDsl(dslMarker = MyDsl::class, safe = SafetyType.Safe)
+annotation class MetaAutoDsl
+
+@AutoDsl(dslMarker = MyDsl::class, safe = SafetyType.Safe)
+class Person(
+        val name: String = "Max",
+        val age: Int,
+        val address: Address?,
+        val friends: List<Person> = emptyList(),
+        @AutoDslRequired("n")
+    val givenName: String? = null,
+        @AutoDslRequired("n")
+    val streetName: String? = null,
+    )
+
+
+@MetaAutoDsl
+data class Address(
+    val street: String,
+    val zipCode: Int,
+    val location: Location?
+)
+
+@AutoDsl(dslMarker = MyDsl::class, safe = SafetyType.Safe)
+class Location {
+    val lat: Double
+    val lng: Double
+
+    constructor() {
+        lat = 0.0
+        lng = 0.0
+    }
+
+    // with multiple constructors you can specify which one to use.
+    @AutoDslConstructor
+    constructor(lat: Double, lng: Double) {
+        this.lat = lat
+        this.lng = lng
+    }
+}

--- a/sample-kapt/src/test/kotlin/com/faendir/kotlin/autodsl/sample/safe/Test.kt
+++ b/sample-kapt/src/test/kotlin/com/faendir/kotlin/autodsl/sample/safe/Test.kt
@@ -1,0 +1,37 @@
+package com.faendir.kotlin.autodsl.sample.safe
+
+import org.junit.jupiter.api.Test
+
+class Test {
+    @Test
+    fun test() {
+        person {
+            name = "Juan"
+            givenName = "Juanno"
+            age = 34
+            address {
+                street = "200 Celebration Bv"
+                zipCode = 34747
+                location {
+                    lat = 100.0
+                    lng = 100.0
+                    this
+                }
+                this
+            }
+            friend {
+                name = "Arturo"
+                age = 28
+                givenName = "A"
+                this
+            }
+            friend {
+                name = "Tiwa"
+                age = 30
+                streetName = "Lil T"
+                this
+            }
+            this
+        }
+    }
+}

--- a/sample-ksp/src/main/kotlin/com/faendir/kotlin/autodsl/sample/safe/Person.kt
+++ b/sample-ksp/src/main/kotlin/com/faendir/kotlin/autodsl/sample/safe/Person.kt
@@ -1,0 +1,50 @@
+package com.faendir.kotlin.autodsl.sample.safe
+
+import com.faendir.kotlin.autodsl.AutoDsl
+import com.faendir.kotlin.autodsl.AutoDslConstructor
+import com.faendir.kotlin.autodsl.AutoDslRequired
+import com.faendir.kotlin.autodsl.SafetyType
+
+@DslMarker
+annotation class MyDsl
+
+@AutoDsl(dslMarker = MyDsl::class, safe = SafetyType.AssignOnce)
+annotation class MetaAutoDsl
+
+@AutoDsl(dslMarker = MyDsl::class, safe = SafetyType.Safe)
+class Person(
+        val name: String = "Max",
+        val age: Int,
+        val address: Address?,
+        val friends: List<Person> = emptyList(),
+        @AutoDslRequired("n")
+    val givenName: String? = null,
+        @AutoDslRequired("n")
+    val streetName: String? = null,
+    )
+
+
+@MetaAutoDsl
+data class Address(
+    val street: String,
+    val zipCode: Int,
+    val location: Location?
+)
+
+@AutoDsl(dslMarker = MyDsl::class, safe = SafetyType.Safe)
+class Location {
+    val lat: Double
+    val lng: Double
+
+    constructor() {
+        lat = 0.0
+        lng = 0.0
+    }
+
+    // with multiple constructors you can specify which one to use.
+    @AutoDslConstructor
+    constructor(lat: Double, lng: Double) {
+        this.lat = lat
+        this.lng = lng
+    }
+}

--- a/sample-ksp/src/test/kotlin/com/faendir/kotlin/autodsl/sample/safe/Test.kt
+++ b/sample-ksp/src/test/kotlin/com/faendir/kotlin/autodsl/sample/safe/Test.kt
@@ -1,0 +1,38 @@
+package com.faendir.kotlin.autodsl.sample.safe
+
+import org.junit.jupiter.api.Test
+
+class Test {
+    @Test
+    fun test() {
+        person {
+            name = "Juan"
+            givenName = "Juanno"
+            age = 34
+            address {
+                street = "200 Celebration Bv"
+                zipCode = 34747
+                //zipCode = 42 // 'val' cannot be reassigned.
+                location {
+                    lat = 100.0
+                    lng = 100.0
+                    this
+                }
+                this
+            }
+            friend {
+                name = "Arturo"
+                age = 28
+                givenName = "A"
+                this
+            }
+            friend {
+                name = "Tiwa"
+                age = 30
+                streetName = "Lil T"
+                this
+            }
+            this
+        }
+    }
+}


### PR DESCRIPTION
Fixes #86, #87

An unsafe version of the API is exposed by using `XBuilderImpl` in case someone needs it. Technically, the builder style `withX` methods can be made safe as well, but I feel they're unlikely to be used in Kotlin, so I've omitted them. `AssignOnce` safety is there to catch simple mistakes, but it can be circumvented incredibly easily with something as simple as `if (true) foo = x; foo = x`. It also currently doesn't do anything for nested dsls (e.g. `PersonBuilder.address`), but maybe it could in the future using error deprecation or an opt-in annotation.
Another point of contention is that types are made nullable no matter what. That's annoying because someone might assign a field, and immediately try to access it, only to have it be nullable. This could be improved in the future, but it'd have to change the logic in `BuilderImpl` classes significantly, and it'd mean that the unsafe version wouldn't have the same semantics as AutoDsl builders do right now (e.g. accessing a required parameter wouldn't give you `null` if it isn't filled yet).

The approach in this PR is incredibly nice and easy to consume in Kotlin (it's my personal favourite). There is an alternative approach that uses type parameters. It would be usable from Java safely (which the current one isn't, with Java consumers having to fall back to the unsafe API), while being slightly more annoying in Kotlin (due to all the type parameters).