### PR TITLE
Support generics in AutoDsl

### DIFF
--- a/processor/src/main/kotlin/com/faendir/kotlin/autodsl/DslGenerator.kt
+++ b/processor/src/main/kotlin/com/faendir/kotlin/autodsl/DslGenerator.kt
@@ -24,16 +24,16 @@ import com.squareup.kotlinpoet.joinToCode
 import io.github.enjoydambience.kotlinbard.TypeSpecBuilder
 import io.github.enjoydambience.kotlinbard.addAnnotation
 import io.github.enjoydambience.kotlinbard.addClass
+import io.github.enjoydambience.kotlinbard.addCode
 import io.github.enjoydambience.kotlinbard.addFunction
+import io.github.enjoydambience.kotlinbard.addParameter
 import io.github.enjoydambience.kotlinbard.addProperty
 import io.github.enjoydambience.kotlinbard.buildFile
 import io.github.enjoydambience.kotlinbard.codeFmt
+import io.github.enjoydambience.kotlinbard.controlFlow
+import io.github.enjoydambience.kotlinbard.`if`
 import io.github.enjoydambience.kotlinbard.nullable
 import java.util.Locale
-import kotlin.jvm.internal.DefaultConstructorMarker
-import kotlin.properties.Delegates
-
-const val DEFAULTS_BITFLAGS_FIELD_NAME = "_defaultsBitField"
 
 class DslGenerator<A, T : A, C : A, P : A>(
     private val kotlinVersion: KotlinVersion,
@@ -91,6 +91,50 @@ class DslGenerator<A, T : A, C : A, P : A>(
         return emptyList()
     }
 
+    private fun generateCopyExtension(clazz: T) {
+        val typeVariables = clazz.getTypeParameters()
+        val type =
+            if (typeVariables.isNotEmpty()) {
+                clazz.asClassName().parameterizedBy(typeVariables)
+            } else {
+                clazz.asClassName()
+            }
+        val constructors = clazz.getConstructors().filter { it.isAccessible() }
+        if (constructors.isEmpty()) {
+            error("must have at least one public or internal constructor", clazz)
+            return
+        }
+        val constructor =
+            constructors.firstOrNull { it.hasAnnotation(AutoDslConstructor::class) }
+                ?: clazz.getPrimaryConstructor()
+                ?: constructors.first()
+        val parameters = constructor.getParameters()
+        val propertyNames = clazz.getPropertyNames()
+
+        buildFile(type.toRawType().packageName, "${type.toRawType().simpleNames.joinToString("")}Copy") {
+            addFunction("copy") {
+                if (typeVariables.isNotEmpty()) {
+                    addTypeVariables(typeVariables)
+                }
+                receiver(type)
+                returns(type)
+
+                for (parameter in parameters) {
+                    val hasProperty = propertyNames.contains(parameter.getName())
+
+                    addParameter(parameter.getName(), parameter.getTypeName(clazz)) {
+                        if (hasProperty) {
+                            defaultValue("this.%L", parameter.getName())
+                        }
+                    }
+                }
+
+                val args = parameters.joinToString(", ") { "${it.getName()} = ${it.getName()}" }
+                addStatement("return %T(%L)", type, args)
+            }
+        }.writeTo(clazz, codeGenerator)
+    }
+
     /**
      * returns true if class generation was successful
      */
@@ -101,6 +145,9 @@ class DslGenerator<A, T : A, C : A, P : A>(
         if (entity.isAbstract()) {
             error("must not be abstract", entity)
             return false
+        }
+        if (!entity.isDataClass()) {
+            generateCopyExtension(entity)
         }
         val constructors = entity.getConstructors().filter { it.isAccessible() }
         if (constructors.isEmpty()) {
@@ -121,20 +168,11 @@ class DslGenerator<A, T : A, C : A, P : A>(
         val entityTypeParameters = entity.getTypeParameters()
         val entityType: TypeName = entityClass.parameterize(entityTypeParameters)
         val builderType: TypeName = builderClass.parameterize(entityTypeParameters)
-        val bitFieldIndices = 0..parameters.size / 32
         val typePrefix = entityClass.simpleNames.joinToString("")
         buildFile(entityClass.packageName, "${typePrefix}Dsl") {
             addClass(builderClass.simpleName) {
                 for (typeParam in entityTypeParameters) {
                     addTypeVariable(typeParam)
-                }
-                if (parameters.any { it.hasDefault }) {
-                    for (i in bitFieldIndices) {
-                        addProperty(DEFAULTS_BITFLAGS_FIELD_NAME + i, INT, KModifier.PRIVATE) {
-                            mutable(true)
-                            initializer("-1")
-                        }
-                    }
                 }
                 for (parameter in parameters) {
                     addParameterProperty(parameter, entityClass)
@@ -157,46 +195,26 @@ class DslGenerator<A, T : A, C : A, P : A>(
                             parameters.joinToString(separator = ",·", prefix = if (parameters.size > 1) "One·of·" else "") { it.name },
                         )
                     }
-                    if (parameters.any { it.hasDefault }) {
-                        addStatement(
-                            "return %T::class.java.getConstructor(%L, %L, %L).newInstance(%L, %L, null)",
-                            entityClass,
-                            parameters
-                                .map {
-                                    "%T::class.%L".codeFmt(
-                                        it.typeName.toRawType().nonnull,
-                                        if (it.typeName.isNullable) "javaObjectType" else "java",
-                                    )
-                                }.joinToCode(),
-                            bitFieldIndices.map { "%T::class.java".codeFmt(INT) }.joinToCode(),
-                            if (kotlinVersion.isAtLeast(1, 5)) {
-                                "%T::class.java".codeFmt(DefaultConstructorMarker::class.asClassName())
-                            } else {
-                                "Class.forName(%S)".codeFmt(DefaultConstructorMarker::class.java.name)
-                            },
-                            parameters
-                                .map {
-                                    when {
-                                        it.typeName.isNullable -> "%L"
-                                        it.typeName == BOOLEAN -> "%L ?: false"
-                                        it.typeName == BYTE -> "%L ?: 0"
-                                        it.typeName == SHORT -> "%L ?: 0"
-                                        it.typeName == INT -> "%L ?: 0"
-                                        it.typeName == LONG -> "%L ?: 0"
-                                        it.typeName == CHAR -> "%L ?: '\\u0000'"
-                                        it.typeName == FLOAT -> "%L ?: 0.0f"
-                                        it.typeName == DOUBLE -> "%L ?: 0.0"
-                                        else -> "%L"
-                                    }.codeFmt(it.name)
-                                }.joinToCode(),
-                            bitFieldIndices.map { "%L".codeFmt(DEFAULTS_BITFLAGS_FIELD_NAME + it) }.joinToCode(),
-                        )
+
+                    val constructorArgs =
+                        parameters
+                            .filter { !it.hasDefault }
+                            .joinToString(", ") { param ->
+                                val assertion = if (param.typeName.isNullable) "" else "!!"
+                                "${param.name} = this.${param.name}$assertion"
+                            }
+
+                    addStatement("val base = %T(%L)", entityType, constructorArgs)
+
+                    val copyArgs =
+                        parameters
+                            .filter { it.hasDefault }
+                            .joinToString(", ") { "${it.name} = this.${it.name} ?: base.${it.name}" }
+
+                    if (copyArgs.isBlank()) {
+                        addStatement("return base")
                     } else {
-                        addStatement(
-                            "return %T(%L)",
-                            entityClass,
-                            parameters.map { (if (it.typeName.isNullable) "%L" else "%L!!").codeFmt(it.name) }.joinToCode(),
-                        )
+                        addStatement("return base.copy(%L)", copyArgs)
                     }
                 }
                 addAnnotation(DslInspect::class)
@@ -278,16 +296,7 @@ class DslGenerator<A, T : A, C : A, P : A>(
         entityClass: ClassName,
     ) = addProperty(parameter.name, parameter.typeName.nullable) {
         mutable(true)
-        if (parameter.hasDefault) {
-            delegate(
-                "%1T.observable(null)·{·_, _, _·-> %2L·= %2L and %3L }",
-                Delegates::class.asClassName(),
-                DEFAULTS_BITFLAGS_FIELD_NAME + (parameter.index / 32),
-                (1 shl parameter.index % 32).inv(),
-            )
-        } else {
-            initializer("null")
-        }
+        initializer("null")
         if (parameter.isMandatory) {
             addAnnotation(DslMandatory::class) {
                 useSiteTarget(AnnotationSpec.UseSiteTarget.SET)

--- a/processor/src/main/kotlin/com/faendir/kotlin/autodsl/DslGenerator.kt
+++ b/processor/src/main/kotlin/com/faendir/kotlin/autodsl/DslGenerator.kt
@@ -34,6 +34,9 @@ import io.github.enjoydambience.kotlinbard.controlFlow
 import io.github.enjoydambience.kotlinbard.`if`
 import io.github.enjoydambience.kotlinbard.nullable
 import java.util.Locale
+import kotlin.properties.Delegates
+
+const val DEFAULTS_BITFLAGS_FIELD_NAME = "_defaultsBitField"
 
 class DslGenerator<A, T : A, C : A, P : A>(
     private val kotlinVersion: KotlinVersion,
@@ -168,11 +171,20 @@ class DslGenerator<A, T : A, C : A, P : A>(
         val entityTypeParameters = entity.getTypeParameters()
         val entityType: TypeName = entityClass.parameterize(entityTypeParameters)
         val builderType: TypeName = builderClass.parameterize(entityTypeParameters)
+        val bitFieldIndices = 0..parameters.size / 32
         val typePrefix = entityClass.simpleNames.joinToString("")
         buildFile(entityClass.packageName, "${typePrefix}Dsl") {
             addClass(builderClass.simpleName) {
                 for (typeParam in entityTypeParameters) {
                     addTypeVariable(typeParam)
+                }
+                if (parameters.any { it.hasDefault }) {
+                    for (i in bitFieldIndices) {
+                        addProperty(DEFAULTS_BITFLAGS_FIELD_NAME + i, INT, KModifier.PRIVATE) {
+                            mutable(true)
+                            initializer("-1")
+                        }
+                    }
                 }
                 for (parameter in parameters) {
                     addParameterProperty(parameter, entityClass)
@@ -209,7 +221,12 @@ class DslGenerator<A, T : A, C : A, P : A>(
                     val copyArgs =
                         parameters
                             .filter { it.hasDefault }
-                            .joinToString(", ") { "${it.name} = this.${it.name} ?: base.${it.name}" }
+                            .joinToString(", ") { param ->
+                                val fieldName = DEFAULTS_BITFLAGS_FIELD_NAME + (param.index / 32)
+                                val bitMask = 1 shl (param.index % 32)
+                                val assertion = if (param.typeName.isNullable) "" else "!!"
+                                "${param.name} = if (($fieldName and $bitMask == 0)) this.${param.name}$assertion else base.${param.name}"
+                            }
 
                     if (copyArgs.isBlank()) {
                         addStatement("return base")
@@ -296,7 +313,16 @@ class DslGenerator<A, T : A, C : A, P : A>(
         entityClass: ClassName,
     ) = addProperty(parameter.name, parameter.typeName.nullable) {
         mutable(true)
-        initializer("null")
+        if (parameter.hasDefault) {
+            delegate(
+                "%1T.observable(null)·{·_, _, _·-> %2L·= %2L and %3L }",
+                Delegates::class.asClassName(),
+                DEFAULTS_BITFLAGS_FIELD_NAME + (parameter.index / 32),
+                (1 shl parameter.index % 32).inv(),
+            )
+        } else {
+            initializer("null")
+        }
         if (parameter.isMandatory) {
             addAnnotation(DslMandatory::class) {
                 useSiteTarget(AnnotationSpec.UseSiteTarget.SET)

--- a/processor/src/main/kotlin/com/faendir/kotlin/autodsl/DslGenerator.kt
+++ b/processor/src/main/kotlin/com/faendir/kotlin/autodsl/DslGenerator.kt
@@ -16,6 +16,7 @@ import com.squareup.kotlinpoet.LONG
 import com.squareup.kotlinpoet.ParameterizedTypeName
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.SHORT
+import com.squareup.kotlinpoet.STAR
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeVariableName
 import com.squareup.kotlinpoet.WildcardTypeName
@@ -26,6 +27,8 @@ import io.github.enjoydambience.kotlinbard.addAnnotation
 import io.github.enjoydambience.kotlinbard.addClass
 import io.github.enjoydambience.kotlinbard.addCode
 import io.github.enjoydambience.kotlinbard.addFunction
+import io.github.enjoydambience.kotlinbard.addInterface
+import io.github.enjoydambience.kotlinbard.addObject
 import io.github.enjoydambience.kotlinbard.addParameter
 import io.github.enjoydambience.kotlinbard.addProperty
 import io.github.enjoydambience.kotlinbard.buildFile
@@ -95,7 +98,7 @@ class DslGenerator<A, T : A, C : A, P : A>(
     }
 
     private fun generateCopyExtension(clazz: T) {
-        val typeVariables = clazz.getTypeParameters()
+        val typeVariables = clazz.getTypeVariableNames()
         val type =
             if (typeVariables.isNotEmpty()) {
                 clazz.asClassName().parameterizedBy(typeVariables)
@@ -165,17 +168,17 @@ class DslGenerator<A, T : A, C : A, P : A>(
             // defer processing
             return false
         }
-        val parameters = parameterFactory.getParameters(constructor, entity)
+        val parameters = parameterFactory.getParameters(constructor)
         val entityClass = entity.asClassName()
         val builderClass = entityClass.withBuilderSuffix()
-        val entityTypeParameters = entity.getTypeParameters()
+        val entityTypeParameters = entity.getTypeVariableNames()
         val entityType: TypeName = entityClass.parameterize(entityTypeParameters)
         val builderType: TypeName = builderClass.parameterize(entityTypeParameters)
         val bitFieldIndices = 0..parameters.size / 32
         val typePrefix = entityClass.simpleNames.joinToString("")
         buildFile(entityClass.packageName, "${typePrefix}Dsl") {
             addClass(builderClass.simpleName) {
-                for (typeParam in entityTypeParameters) {
+                entityTypeParameters.forEach { typeParam ->
                     addTypeVariable(typeParam)
                 }
                 if (parameters.any { it.hasDefault }) {
@@ -228,10 +231,11 @@ class DslGenerator<A, T : A, C : A, P : A>(
                                 "${param.name} = if (($fieldName and $bitMask == 0)) this.${param.name}$assertion else base.${param.name}"
                             }
 
+                    val cast = if (entityType is ParameterizedTypeName) " as %L".codeFmt(entityType) else ""
                     if (copyArgs.isBlank()) {
-                        addStatement("return base")
+                        addStatement("return base%L", cast)
                     } else {
-                        addStatement("return base.copy(%L)", copyArgs)
+                        addStatement("return base.copy(%L)%L", copyArgs, cast)
                     }
                 }
                 addAnnotation(DslInspect::class)
@@ -241,7 +245,7 @@ class DslGenerator<A, T : A, C : A, P : A>(
             }
             addFunction(typePrefix.replaceFirstChar { it.lowercase(Locale.getDefault()) }) {
                 addModifiers(KModifier.INLINE)
-                for (typeParam in entityTypeParameters) {
+                entityTypeParameters.forEach { typeParam ->
                     addTypeVariable(typeParam)
                 }
                 addParameter("initializer", builderType.asLambdaReceiver())
@@ -258,23 +262,82 @@ class DslGenerator<A, T : A, C : A, P : A>(
     private fun TypeSpecBuilder.addParameterNestedSetter(parameter: Parameter) =
         addFunction(parameter.name) {
             addModifiers(KModifier.INLINE)
-            val nestedBuilderType = parameter.typeName.withBuilderSuffix()
+            val nestedBuilderType =
+                if (parameter.typeName is ParameterizedTypeName) {
+                    val classVars = parameter.typeVariableNames!!
+                    val typeArgs =
+                        parameter.typeName.typeArguments.mapIndexed { index, arg ->
+                            if (arg is WildcardTypeName) {
+                                if (arg.outTypes == STAR.outTypes) {
+                                    val type = TypeVariableName(classVars[index].name + index, classVars[index].variance)
+                                    addTypeVariable(type)
+                                    type
+                                } else {
+                                    val type = TypeVariableName(classVars[index].name + index, arg.outTypes, classVars[index].variance)
+                                    addTypeVariable(type)
+                                    type
+                                }
+                            } else {
+                                arg
+                            }
+                        }
+                    parameter.typeName.rawType
+                        .parameterizedBy(typeArgs)
+                        .withBuilderSuffix()
+                } else {
+                    parameter.typeName.withBuilderSuffix()
+                }
+            addAnnotation(ClassName("kotlin", "OptIn")) {
+                addMember("%T::class", ClassName("kotlin.contracts", "ExperimentalContracts"))
+            }
             addParameter("initializer", nestedBuilderType.asLambdaReceiver())
-            addStatement("val result = %T().apply(initializer).build()", nestedBuilderType)
-            addStatement("%L = result", parameter.name)
-            addStatement("return result")
+            addCode {
+                addStatement("kotlin.contracts.contract { callsInPlace(initializer, kotlin.contracts.InvocationKind.EXACTLY_ONCE) }")
+                addStatement("val result = %T().apply(initializer).build()", nestedBuilderType)
+                addStatement("%L = result", parameter.name)
+                addStatement("return result")
+            }
             returns(parameter.typeName.nonnull)
         }
 
     private fun TypeSpecBuilder.addParameterNestedAdder(parameter: Parameter) =
         addFunction(parameter.collectionType!!.singular) {
             addModifiers(KModifier.INLINE)
-            val elementType = (parameter.typeName as ParameterizedTypeName).typeArguments.first()
+            val rawElementType = (parameter.typeName as ParameterizedTypeName).typeArguments.first()
+            val elementType =
+                if (rawElementType is ParameterizedTypeName) {
+                    val classVars = parameter.typeVariableNames!!
+                    val typeArgs =
+                        rawElementType.typeArguments.mapIndexed { index, arg ->
+                            if (arg is WildcardTypeName) {
+                                if (arg.outTypes == STAR.outTypes) {
+                                    val type = TypeVariableName(classVars[index].name + index, classVars[index].variance)
+                                    addTypeVariable(type)
+                                    type
+                                } else {
+                                    val type = TypeVariableName(classVars[index].name + index, arg.outTypes, classVars[index].variance)
+                                    addTypeVariable(type)
+                                    type
+                                }
+                            } else {
+                                arg
+                            }
+                        }
+                    rawElementType.rawType.parameterizedBy(typeArgs)
+                } else {
+                    rawElementType
+                }
             val nestedBuilderType = elementType.withBuilderSuffix()
+            addAnnotation(ClassName("kotlin", "OptIn")) {
+                addMember("%T::class", ClassName("kotlin.contracts", "ExperimentalContracts"))
+            }
             addParameter("initializer", nestedBuilderType.asLambdaReceiver())
-            addStatement("val result = %T().apply(initializer).build()", nestedBuilderType)
-            addStatement("%1L = %1L?.plus(result) ?: %2L(result)", parameter.name, parameter.collectionType.createFunction)
-            addStatement("return result")
+            addCode {
+                addStatement("kotlin.contracts.contract { callsInPlace(initializer, kotlin.contracts.InvocationKind.EXACTLY_ONCE) }")
+                addStatement("val result = %T().apply(initializer).build()", nestedBuilderType)
+                addStatement("%1L = %1L?.plus(result) ?: %2L(result)", parameter.name, parameter.collectionType.createFunction)
+                addStatement("return result")
+            }
             returns(elementType.nonnull)
         }
 
@@ -332,4 +395,5 @@ class DslGenerator<A, T : A, C : A, P : A>(
         parameter.doc?.let { addKdoc(it) }
         addKdoc("@see %T.%L", entityClass, parameter.name)
     }
+
 }

--- a/processor/src/main/kotlin/com/faendir/kotlin/autodsl/DslGenerator.kt
+++ b/processor/src/main/kotlin/com/faendir/kotlin/autodsl/DslGenerator.kt
@@ -98,7 +98,7 @@ class DslGenerator<A, T : A, C : A, P : A>(
     }
 
     private fun generateCopyExtension(clazz: T) {
-        val typeVariables = clazz.getTypeVariableNames()
+        val typeVariables = clazz.getTypeVariableNames().map { it.withoutVariance() as TypeVariableName }
         val type =
             if (typeVariables.isNotEmpty()) {
                 clazz.asClassName().parameterizedBy(typeVariables)
@@ -171,7 +171,7 @@ class DslGenerator<A, T : A, C : A, P : A>(
         val parameters = parameterFactory.getParameters(constructor)
         val entityClass = entity.asClassName()
         val builderClass = entityClass.withBuilderSuffix()
-        val entityTypeParameters = entity.getTypeVariableNames()
+        val entityTypeParameters = entity.getTypeVariableNames().map { it.withoutVariance() as TypeVariableName }
         val entityType: TypeName = entityClass.parameterize(entityTypeParameters)
         val builderType: TypeName = builderClass.parameterize(entityTypeParameters)
         val bitFieldIndices = 0..parameters.size / 32
@@ -395,5 +395,4 @@ class DslGenerator<A, T : A, C : A, P : A>(
         parameter.doc?.let { addKdoc(it) }
         addKdoc("@see %T.%L", entityClass, parameter.name)
     }
-
 }

--- a/processor/src/main/kotlin/com/faendir/kotlin/autodsl/KotlinPoetUtils.kt
+++ b/processor/src/main/kotlin/com/faendir/kotlin/autodsl/KotlinPoetUtils.kt
@@ -9,6 +9,7 @@ import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeVariableName
 import com.squareup.kotlinpoet.WildcardTypeName
 import com.squareup.kotlinpoet.asClassName
+import io.github.enjoydambience.kotlinbard.reified
 
 @Suppress("UNCHECKED_CAST")
 val <T : TypeName> T.nonnull: T
@@ -31,12 +32,16 @@ fun TypeName.withoutVariance(): TypeName =
                     // Strip the variance/projection, keep the underlying type
                     if (arg is WildcardTypeName) {
                         // This extracts the bound and removes the out/in projection
-                        arg.inTypes.firstOrNull() ?: arg.outTypes.firstOrNull()  ?: ANY
+                        arg.inTypes.firstOrNull() ?: arg.outTypes.firstOrNull() ?: ANY
                     } else {
                         arg
                     }
                 }
             this.rawType.parameterizedBy(newArgs)
+        }
+
+        is TypeVariableName -> {
+            TypeVariableName(name, bounds).copy(nullable = this.isNullable, annotations = this.annotations, tags = this.tags)
         }
 
         else -> {

--- a/processor/src/main/kotlin/com/faendir/kotlin/autodsl/KotlinPoetUtils.kt
+++ b/processor/src/main/kotlin/com/faendir/kotlin/autodsl/KotlinPoetUtils.kt
@@ -1,5 +1,6 @@
 package com.faendir.kotlin.autodsl
 
+import com.squareup.kotlinpoet.ANY
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.LambdaTypeName
 import com.squareup.kotlinpoet.ParameterizedTypeName
@@ -19,8 +20,28 @@ fun TypeName.toRawType(): ClassName =
         is ClassName -> this
         is WildcardTypeName -> this.inTypes.firstOrNull()?.toRawType() ?: this.outTypes.first().toRawType()
         is LambdaTypeName -> ClassName("kotlin", "Function${(if (receiver != null) 1 else 0) + parameters.size}")
-        is TypeVariableName -> Any::class.asClassName()
         else -> throw IllegalArgumentException("Unsupported conversion to raw type from $this")
+    }
+
+fun TypeName.withoutVariance(): TypeName =
+    when (this) {
+        is ParameterizedTypeName -> {
+            val newArgs =
+                typeArguments.map { arg ->
+                    // Strip the variance/projection, keep the underlying type
+                    if (arg is WildcardTypeName) {
+                        // This extracts the bound and removes the out/in projection
+                        arg.inTypes.firstOrNull() ?: arg.outTypes.firstOrNull()  ?: ANY
+                    } else {
+                        arg
+                    }
+                }
+            this.rawType.parameterizedBy(newArgs)
+        }
+
+        else -> {
+            this
+        }
     }
 
 fun TypeName.withoutAnnotations(): TypeName =
@@ -67,6 +88,11 @@ fun TypeName.withoutAnnotations(): TypeName =
 
 fun ClassName.withBuilderSuffix() = ClassName(packageName, "${simpleNames.joinToString("")}Builder")
 
-fun TypeName.withBuilderSuffix() = toRawType().withBuilderSuffix()
+fun TypeName.withBuilderSuffix(): TypeName =
+    when (this) {
+        is ParameterizedTypeName -> rawType.withBuilderSuffix().parameterizedBy(typeArguments)
+        is ClassName -> withBuilderSuffix()
+        else -> toRawType().withBuilderSuffix() // Fallback for other TypeName types, though unlikely to be reached for main classes
+    }
 
 fun TypeName.asLambdaReceiver() = LambdaTypeName.get(receiver = this, returnType = Unit::class.asClassName())

--- a/processor/src/main/kotlin/com/faendir/kotlin/autodsl/SourceInfoResolver.kt
+++ b/processor/src/main/kotlin/com/faendir/kotlin/autodsl/SourceInfoResolver.kt
@@ -38,19 +38,21 @@ interface SourceInfoResolver<ANNOTATED, TYPE : ANNOTATED, CONSTRUCTOR : ANNOTATE
 
     fun TYPE.getPrimaryConstructor(): CONSTRUCTOR?
 
+    fun CONSTRUCTOR.getParentType(): TYPE
+
     fun CONSTRUCTOR.isValid(): Boolean
 
     fun CONSTRUCTOR.getParameters(): List<PARAMETER>
 
     fun TYPE.asClassName(): ClassName
 
-    fun TYPE.getTypeParameters(): List<TypeVariableName>
+    fun TYPE.getTypeVariableNames(): List<TypeVariableName>
 
     fun PARAMETER.getTypeDeclaration(): TYPE?
 
     fun PARAMETER.getTypeArguments(): List<TYPE>
 
-    fun PARAMETER.getTypeName(enclosingType: TYPE): TypeName
+    fun PARAMETER.getTypeName(parent: TYPE? = null): TypeName
 
     fun PARAMETER.getName(): String
 

--- a/processor/src/main/kotlin/com/faendir/kotlin/autodsl/SourceInfoResolver.kt
+++ b/processor/src/main/kotlin/com/faendir/kotlin/autodsl/SourceInfoResolver.kt
@@ -28,7 +28,11 @@ interface SourceInfoResolver<ANNOTATED, TYPE : ANNOTATED, CONSTRUCTOR : ANNOTATE
 
     fun TYPE.isAbstract(): Boolean
 
+    fun TYPE.isDataClass(): Boolean
+
     fun TYPE.getConstructors(): List<CONSTRUCTOR>
+
+    fun TYPE.getPropertyNames(): Set<String>
 
     fun CONSTRUCTOR.isAccessible(): Boolean
 

--- a/processor/src/main/kotlin/com/faendir/kotlin/autodsl/kapt/KaptSourceInfoResolver.kt
+++ b/processor/src/main/kotlin/com/faendir/kotlin/autodsl/kapt/KaptSourceInfoResolver.kt
@@ -96,6 +96,8 @@ class KaptSourceInfoResolver(
 
     override fun Type.isAbstract(): Boolean = typeSpec.modifiers.contains(KModifier.ABSTRACT)
 
+    override fun Type.isDataClass(): Boolean = typeSpec.modifiers.contains(KModifier.DATA)
+
     override fun Type.getConstructors(): List<Constructor> {
         val constructorElements =
             element.enclosedElements
@@ -147,6 +149,11 @@ class KaptSourceInfoResolver(
         KModifier.PRIVATE !in constructorSpec.modifiers && KModifier.PROTECTED !in constructorSpec.modifiers
 
     override fun Type.getPrimaryConstructor(): Constructor? = getConstructors().find { it.isPrimary }
+
+    override fun Type.getPropertyNames(): Set<String> =
+        this.typeSpec.propertySpecs
+            .map { it.name }
+            .toSet()
 
     override fun Constructor.isValid(): Boolean = true
 

--- a/processor/src/main/kotlin/com/faendir/kotlin/autodsl/kapt/KaptSourceInfoResolver.kt
+++ b/processor/src/main/kotlin/com/faendir/kotlin/autodsl/kapt/KaptSourceInfoResolver.kt
@@ -222,7 +222,13 @@ class KaptSourceInfoResolver(
 
     override fun Type.getTypeVariableNames(): List<TypeVariableName> =
         typeSpec.typeVariables.map { typeVariableName ->
-            typeVariableName.copy(bounds = typeVariableName.bounds.filterNot { it == ClassName("kotlin", "Any") || it == ClassName("java.lang", "Object") })
+            typeVariableName.copy(
+                bounds =
+                    typeVariableName.bounds.filterNot {
+                        it == ClassName("kotlin", "Any") ||
+                            it == ClassName("java.lang", "Object")
+                    },
+            )
         }
 }
 

--- a/processor/src/main/kotlin/com/faendir/kotlin/autodsl/kapt/KaptSourceInfoResolver.kt
+++ b/processor/src/main/kotlin/com/faendir/kotlin/autodsl/kapt/KaptSourceInfoResolver.kt
@@ -5,6 +5,7 @@ import com.faendir.kotlin.autodsl.SourceInfoResolver
 import com.faendir.kotlin.autodsl.nonnull
 import com.faendir.kotlin.autodsl.toRawType
 import com.faendir.kotlin.autodsl.withoutAnnotations
+import com.faendir.kotlin.autodsl.withoutVariance
 import com.google.devtools.ksp.symbol.ClassKind
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.DelicateKotlinPoetApi
@@ -18,7 +19,9 @@ import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.TypeVariableName
 import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.asTypeName
+import com.squareup.kotlinpoet.asTypeVariableName
 import com.squareup.kotlinpoet.metadata.classinspectors.ElementsClassInspector
+import com.squareup.kotlinpoet.metadata.specs.classFor
 import com.squareup.kotlinpoet.metadata.specs.toTypeSpec
 import javax.annotation.processing.ProcessingEnvironment
 import javax.annotation.processing.RoundEnvironment
@@ -28,9 +31,9 @@ import javax.lang.model.element.ElementKind
 import javax.lang.model.element.ExecutableElement
 import javax.lang.model.element.TypeElement
 import javax.lang.model.element.VariableElement
-import javax.lang.model.type.DeclaredType
 import javax.lang.model.type.MirroredTypeException
 import javax.lang.model.type.TypeMirror
+import kotlin.collections.mapNotNull
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty1
 
@@ -40,6 +43,8 @@ class KaptSourceInfoResolver(
     private val roundEnv: RoundEnvironment,
 ) : AnnotationFinder<Annotated>(),
     SourceInfoResolver<Annotated, Type, Constructor, Parameter> {
+    private val classInspector = ElementsClassInspector.create(lenient = true, processingEnv.elementUtils, processingEnv.typeUtils)
+
     private fun Set<Element>.mapToTypes() = filterIsInstance<TypeElement>().map { Type(it, it.toTypeSpec()) }
 
     override fun getClassesWithAnnotation(annotation: KClass<out Annotation>): List<Type> =
@@ -94,9 +99,9 @@ class KaptSourceInfoResolver(
 
     override fun Annotated.getQualifiedName(): String? = (this as? Type)?.element?.qualifiedName?.toString()
 
-    override fun Type.isAbstract(): Boolean = typeSpec.modifiers.contains(KModifier.ABSTRACT)
+    override fun Type.isAbstract(): Boolean = KModifier.ABSTRACT in typeSpec.modifiers
 
-    override fun Type.isDataClass(): Boolean = typeSpec.modifiers.contains(KModifier.DATA)
+    override fun Type.isDataClass(): Boolean = KModifier.DATA in typeSpec.modifiers
 
     override fun Type.getConstructors(): List<Constructor> {
         val constructorElements =
@@ -123,11 +128,6 @@ class KaptSourceInfoResolver(
                                     eType.rawType == kType.rawType
                                 }
 
-                                is TypeVariableName if kType is TypeVariableName -> {
-                                    // Bounds may be variant in java, just check name
-                                    eType.name == kType.name
-                                }
-
                                 is ParameterizedTypeName if kType is LambdaTypeName -> {
                                     // Lambdas are kotlin.FunctionX types in java
                                     eType.typeArguments.map { it.toRawType() } ==
@@ -135,25 +135,31 @@ class KaptSourceInfoResolver(
                                         kType.returnType
                                 }
 
+                                is TypeVariableName if kType is TypeVariableName -> {
+                                    eType.name == kType.name
+                                }
+
                                 else -> {
-                                    eType == kType
+                                    eType.withoutVariance() == kType.withoutVariance()
                                 }
                             }
                         }
                 }
-            Constructor(element, constructorSpec, isPrimary)
+            Constructor(this, element, constructorSpec, isPrimary)
         }
     }
+
+    override fun Type.getPropertyNames(): Set<String> =
+        this.typeSpec.propertySpecs
+            .map { it.name }
+            .toSet()
 
     override fun Constructor.isAccessible(): Boolean =
         KModifier.PRIVATE !in constructorSpec.modifiers && KModifier.PROTECTED !in constructorSpec.modifiers
 
     override fun Type.getPrimaryConstructor(): Constructor? = getConstructors().find { it.isPrimary }
 
-    override fun Type.getPropertyNames(): Set<String> =
-        this.typeSpec.propertySpecs
-            .map { it.name }
-            .toSet()
+    override fun Constructor.getParentType(): Type = parent
 
     override fun Constructor.isValid(): Boolean = true
 
@@ -167,8 +173,6 @@ class KaptSourceInfoResolver(
 
     override fun Type.asClassName(): ClassName = element.asClassName()
 
-    override fun Type.getTypeParameters(): List<TypeVariableName> = typeSpec.typeVariables
-
     private fun TypeMirror.toType(): Type? =
         (processingEnv.typeUtils.asElement(this) as? TypeElement)?.let { element ->
             try {
@@ -178,11 +182,26 @@ class KaptSourceInfoResolver(
             }
         }
 
+    private fun TypeName.toType(): Type? {
+        val className = (this as? ClassName) ?: (this as? ParameterizedTypeName)?.rawType ?: return null
+        val typeElement = processingEnv.elementUtils.getTypeElement(className.canonicalName) ?: return null
+
+        return Type(typeElement, typeElement.toTypeSpec())
+    }
+
     override fun Parameter.getTypeDeclaration(): Type? = element.asType().toType()
 
-    override fun Parameter.getTypeArguments(): List<Type> = (element.asType() as DeclaredType).typeArguments.mapNotNull { it.toType() }
+    override fun Parameter.getTypeArguments(): List<Type> {
+        val type = parameterSpec.type
 
-    override fun Parameter.getTypeName(enclosingType: Type): TypeName = parameterSpec.type
+        val parameterizedType = type as? ParameterizedTypeName ?: return emptyList()
+
+        return parameterizedType.typeArguments.mapNotNull { typeName ->
+            typeName.toType()
+        }
+    }
+
+    override fun Parameter.getTypeName(parent: Type?): TypeName = parameterSpec.type
 
     override fun Parameter.getName(): String = parameterSpec.name
 
@@ -190,9 +209,21 @@ class KaptSourceInfoResolver(
 
     override fun Parameter.getDoc(): String? = processingEnv.elementUtils.getDocComment(element)
 
-    private val classInspector = ElementsClassInspector.create(lenient = true, processingEnv.elementUtils, processingEnv.typeUtils)
+    private fun TypeElement.toTypeSpec(): TypeSpec =
+        if (this.getAnnotation(Metadata::class.java) != null) {
+            try {
+                toTypeSpec(lenient = true, classInspector)
+            } catch (_: Exception) {
+                TypeSpec.classBuilder(this.simpleName.toString()).build()
+            }
+        } else {
+            TypeSpec.classBuilder(this.simpleName.toString()).build()
+        }
 
-    private fun TypeElement.toTypeSpec() = toTypeSpec(lenient = true, classInspector)
+    override fun Type.getTypeVariableNames(): List<TypeVariableName> =
+        typeSpec.typeVariables.map { typeVariableName ->
+            typeVariableName.copy(bounds = typeVariableName.bounds.filterNot { it == ClassName("kotlin", "Any") || it == ClassName("java.lang", "Object") })
+        }
 }
 
 interface Annotated {
@@ -213,6 +244,7 @@ class Type(
 }
 
 class Constructor(
+    internal val parent: Type,
     internal val element: ExecutableElement,
     internal val constructorSpec: FunSpec,
     internal val isPrimary: Boolean,

--- a/processor/src/main/kotlin/com/faendir/kotlin/autodsl/kapt/Utils.kt
+++ b/processor/src/main/kotlin/com/faendir/kotlin/autodsl/kapt/Utils.kt
@@ -4,6 +4,7 @@ import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.ParameterizedTypeName
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.TypeName
+import com.squareup.kotlinpoet.TypeVariableName
 import com.squareup.kotlinpoet.WildcardTypeName
 import org.jetbrains.kotlin.builtins.jvm.JavaToKotlinClassMap
 import org.jetbrains.kotlin.name.ClassId
@@ -31,6 +32,10 @@ fun TypeName.mapToKotlin(): TypeName =
             } else {
                 WildcardTypeName.consumerOf(inTypes.first().mapToKotlin())
             }
+        }
+
+        is TypeVariableName -> {
+            this
         }
 
         else -> {

--- a/processor/src/main/kotlin/com/faendir/kotlin/autodsl/ksp/KspSourceInfoResolver.kt
+++ b/processor/src/main/kotlin/com/faendir/kotlin/autodsl/ksp/KspSourceInfoResolver.kt
@@ -19,10 +19,12 @@ import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeVariableName
 import com.squareup.kotlinpoet.asClassName
+import com.squareup.kotlinpoet.ksp.TypeParameterResolver
 import com.squareup.kotlinpoet.ksp.toClassName
 import com.squareup.kotlinpoet.ksp.toTypeName
 import com.squareup.kotlinpoet.ksp.toTypeParameterResolver
 import com.squareup.kotlinpoet.ksp.toTypeVariableName
+import io.github.enjoydambience.kotlinbard.nullable
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty1
 import com.google.devtools.ksp.getConstructors as superGetConstructors
@@ -71,9 +73,9 @@ class KspSourceInfoResolver(
 
     override fun KSAnnotated.getQualifiedName(): String? = (this as? KSClassDeclaration)?.qualifiedName?.asString()
 
-    override fun KSClassDeclaration.isAbstract(): Boolean = modifiers.contains(Modifier.ABSTRACT)
+    override fun KSClassDeclaration.isAbstract(): Boolean = Modifier.ABSTRACT in modifiers
 
-    override fun KSClassDeclaration.isDataClass(): Boolean = modifiers.contains(Modifier.DATA)
+    override fun KSClassDeclaration.isDataClass(): Boolean = Modifier.DATA in modifiers
 
     override fun KSClassDeclaration.getConstructors(): List<KSFunctionDeclaration> = superGetConstructors().toList()
 
@@ -83,28 +85,34 @@ class KspSourceInfoResolver(
 
     override fun KSClassDeclaration.getPrimaryConstructor(): KSFunctionDeclaration? = primaryConstructor
 
+    override fun KSFunctionDeclaration.getParentType(): KSClassDeclaration = parentDeclaration as KSClassDeclaration
+
     override fun KSFunctionDeclaration.isValid(): Boolean = validate()
 
     override fun KSFunctionDeclaration.getParameters(): List<KSValueParameter> = parameters
 
     override fun KSClassDeclaration.asClassName(): ClassName = toClassName()
 
-    override fun KSClassDeclaration.getTypeParameters(): List<TypeVariableName> {
-        val resolver = typeParameters.toTypeParameterResolver()
-        return typeParameters.map { it.toTypeVariableName(resolver) }
-    }
-
     override fun KSValueParameter.getTypeDeclaration(): KSClassDeclaration? = type.resolve().declaration as? KSClassDeclaration
 
     override fun KSValueParameter.getTypeArguments(): List<KSClassDeclaration> =
         type.resolve().arguments.mapNotNull { it.type?.resolve()?.declaration as? KSClassDeclaration }
 
-    override fun KSValueParameter.getTypeName(enclosingType: KSClassDeclaration): TypeName =
-        type.toTypeName(enclosingType.typeParameters.toTypeParameterResolver())
+    override fun KSValueParameter.getTypeName(parent: KSClassDeclaration?): TypeName =
+        type.toTypeName(parent?.typeParameters?.toTypeParameterResolver() ?: TypeParameterResolver.EMPTY)
 
     override fun KSValueParameter.getName(): String = name!!.asString()
 
     override fun KSValueParameter.hasDefault(): Boolean = hasDefault
 
     override fun KSValueParameter.getDoc(): String? = null
+
+    override fun KSClassDeclaration.getTypeVariableNames(): List<TypeVariableName> =
+        typeParameters.map { it.toTypeVariableName(typeParameters.toTypeParameterResolver()) }.map { typeVariableName ->
+            if (typeVariableName.bounds.contains(ClassName("kotlin", "Any").nullable)) {
+                typeVariableName.copy(bounds = typeVariableName.bounds.filterNot { it == ClassName("kotlin", "Any").nullable })
+            } else {
+                typeVariableName
+            }
+        }
 }

--- a/processor/src/main/kotlin/com/faendir/kotlin/autodsl/ksp/KspSourceInfoResolver.kt
+++ b/processor/src/main/kotlin/com/faendir/kotlin/autodsl/ksp/KspSourceInfoResolver.kt
@@ -73,7 +73,12 @@ class KspSourceInfoResolver(
 
     override fun KSClassDeclaration.isAbstract(): Boolean = modifiers.contains(Modifier.ABSTRACT)
 
+    override fun KSClassDeclaration.isDataClass(): Boolean = modifiers.contains(Modifier.DATA)
+
     override fun KSClassDeclaration.getConstructors(): List<KSFunctionDeclaration> = superGetConstructors().toList()
+
+    override fun KSClassDeclaration.getPropertyNames(): Set<String> =
+        getAllProperties().map { it.simpleName.asString() }.toSet()
 
     override fun KSFunctionDeclaration.isAccessible(): Boolean = isPublic() || isInternal()
 

--- a/processor/src/main/kotlin/com/faendir/kotlin/autodsl/ksp/KspSourceInfoResolver.kt
+++ b/processor/src/main/kotlin/com/faendir/kotlin/autodsl/ksp/KspSourceInfoResolver.kt
@@ -77,8 +77,7 @@ class KspSourceInfoResolver(
 
     override fun KSClassDeclaration.getConstructors(): List<KSFunctionDeclaration> = superGetConstructors().toList()
 
-    override fun KSClassDeclaration.getPropertyNames(): Set<String> =
-        getAllProperties().map { it.simpleName.asString() }.toSet()
+    override fun KSClassDeclaration.getPropertyNames(): Set<String> = getAllProperties().map { it.simpleName.asString() }.toSet()
 
     override fun KSFunctionDeclaration.isAccessible(): Boolean = isPublic() || isInternal()
 

--- a/processor/src/main/kotlin/com/faendir/kotlin/autodsl/parameter/Parameter.kt
+++ b/processor/src/main/kotlin/com/faendir/kotlin/autodsl/parameter/Parameter.kt
@@ -1,9 +1,11 @@
 package com.faendir.kotlin.autodsl.parameter
 
 import com.squareup.kotlinpoet.TypeName
+import com.squareup.kotlinpoet.TypeVariableName
 
 class Parameter(
     val typeName: TypeName,
+    val typeVariableNames: List<TypeVariableName>?,
     val name: String,
     val doc: String?,
     val hasDefault: Boolean,
@@ -18,14 +20,15 @@ class Parameter(
 
 sealed class CollectionType(
     val createFunction: String,
+    val builderFunction: String,
     val convertFunction: String,
     val singular: String,
 ) {
     class ListType(
         singular: String,
-    ) : CollectionType("listOf", "toList", singular)
+    ) : CollectionType("listOf", "buildList", "toList", singular)
 
     class SetType(
         singular: String,
-    ) : CollectionType("setOf", "toSet", singular)
+    ) : CollectionType("setOf", "buildSet", "toSet", singular)
 }

--- a/processor/src/main/kotlin/com/faendir/kotlin/autodsl/parameter/ParameterFactory.kt
+++ b/processor/src/main/kotlin/com/faendir/kotlin/autodsl/parameter/ParameterFactory.kt
@@ -9,6 +9,7 @@ import com.faendir.kotlin.autodsl.parameter.CollectionType.SetType
 import com.faendir.kotlin.autodsl.toRawType
 import com.shadow.pluralize.singularize
 import com.shadow.pluralize.utils.Plurality
+import com.squareup.kotlinpoet.TypeVariableName
 import com.squareup.kotlinpoet.asClassName
 import kotlin.reflect.KClass
 
@@ -21,13 +22,10 @@ class ParameterFactory<A, T : A, C : A, P : A>(
     private val iterable = Iterable::class.asClassName()
 
     @JvmName("getParametersFromConstructor")
-    fun getParameters(
-        constructor: C,
-        enclosingType: T,
-    ): List<Parameter> =
+    fun getParameters(constructor: C): List<Parameter> =
         constructor.getParameters().withIndex().map { (index, parameter) ->
-            val type = parameter.getTypeName(enclosingType)
-            val rawType = type.toRawType()
+            val type = parameter.getTypeName(constructor.getParentType())
+            val rawType = if (type !is TypeVariableName) type.toRawType() else null
             val (hasNestedDsl, collectionType) =
                 when (rawType) {
                     set -> {
@@ -43,15 +41,22 @@ class ParameterFactory<A, T : A, C : A, P : A>(
                         (parameter.getTypeDeclaration()?.hasAnnotation(AutoDsl::class) == true) to null
                     }
                 }
+            val typeVariableNames =
+                if (collectionType != null) {
+                    parameter.getTypeArguments().firstOrNull()?.getTypeVariableNames()
+                } else {
+                    parameter.getTypeDeclaration()?.getTypeVariableNames()
+                }
             Parameter(
-                typeName = type,
-                name = parameter.getName(),
-                doc = parameter.getDoc(),
-                hasDefault = parameter.hasDefault(),
-                requiredGroup = parameter.getAnnotationProperty(AutoDslRequired::class, AutoDslRequired::group),
-                index = index,
-                hasNestedDsl = hasNestedDsl,
-                collectionType = collectionType,
+                type,
+                typeVariableNames,
+                parameter.getName(),
+                parameter.getDoc(),
+                parameter.hasDefault(),
+                parameter.getAnnotationProperty(AutoDslRequired::class, AutoDslRequired::group),
+                index,
+                hasNestedDsl,
+                collectionType,
             )
         }
 

--- a/processor/src/test/kotlin/com/faendir/kotlin/autodsl/DefaultValuesTest.kt
+++ b/processor/src/test/kotlin/com/faendir/kotlin/autodsl/DefaultValuesTest.kt
@@ -220,4 +220,127 @@ class DefaultValuesTest {
                 }
             """,
         )
+
+    @TestFactory
+    fun `default value in data class`() =
+        compile(
+            """
+                import com.faendir.kotlin.autodsl.AutoDsl
+                @AutoDsl
+                data class Entity(val a: String, val b: String = "Hi")
+            """,
+            """
+                import strikt.api.expectThat
+                import strikt.assertions.isEqualTo
+                fun test() {
+                    expectThat(entity {
+                        a = "a"
+                    }.b).isEqualTo("Hi")
+                }
+            """,
+        )
+
+    @TestFactory
+    fun `explicit null overrides a non-null default value`() =
+        compile(
+            """
+                import com.faendir.kotlin.autodsl.AutoDsl
+                @AutoDsl
+                class Entity(val a: String? = "Hi")
+            """,
+            """
+                import strikt.api.expectThat
+                import strikt.assertions.isEqualTo
+                fun test() {
+                    expectThat(entity {
+                        a = null
+                    }.a).isEqualTo(null)
+                }
+            """,
+        )
+
+    @TestFactory
+    fun `boolean default value overridden with false`() =
+        compile(
+            """
+                import com.faendir.kotlin.autodsl.AutoDsl
+                @AutoDsl
+                class Entity(val a: Boolean = true)
+            """,
+            """
+                import strikt.api.expectThat
+                import strikt.assertions.isEqualTo
+                fun test() {
+                    expectThat(entity {
+                        a = false
+                    }.a).isEqualTo(false)
+                }
+            """,
+        )
+
+    @TestFactory
+    fun `multiple default values with a partial override`() =
+        compile(
+            """
+                import com.faendir.kotlin.autodsl.AutoDsl
+                @AutoDsl
+                class Entity(val a: String = "a", val b: String = "b", val c: String = "c")
+            """,
+            """
+                import strikt.api.expectThat
+                import strikt.assertions.isEqualTo
+                fun test() {
+                    expectThat(entity {
+                        b = "B"
+                    }) {
+                        get(Entity::a).isEqualTo("a")
+                        get(Entity::b).isEqualTo("B")
+                        get(Entity::c).isEqualTo("c")
+                    }
+                }
+            """,
+        )
+
+    @TestFactory
+    fun `default value referencing another constructor parameter`() =
+        compile(
+            """
+                import com.faendir.kotlin.autodsl.AutoDsl
+                @AutoDsl
+                class Entity(val a: Int, val b: Int = a * 2)
+            """,
+            """
+                import strikt.api.expectThat
+                import strikt.assertions.isEqualTo
+                fun test() {
+                    expectThat(entity {
+                        a = 5
+                    }.b).isEqualTo(10)
+                }
+            """,
+        )
+
+    @TestFactory
+    fun `default value combined with nested dsl`() =
+        compile(
+            """
+                import com.faendir.kotlin.autodsl.AutoDsl
+                @AutoDsl
+                class Address(val city: String)
+                @AutoDsl
+                class Entity(val address: Address? = null)
+            """,
+            """
+                import strikt.api.expectThat
+                import strikt.assertions.isEqualTo
+                fun test() {
+                    expectThat(entity {
+                        address {
+                            city = "NYC"
+                        }
+                    }.address?.city).isEqualTo("NYC")
+                    expectThat(entity {}.address).isEqualTo(null)
+                }
+            """,
+        )
 }

--- a/processor/src/test/kotlin/com/faendir/kotlin/autodsl/GenericClassTest.kt
+++ b/processor/src/test/kotlin/com/faendir/kotlin/autodsl/GenericClassTest.kt
@@ -97,4 +97,119 @@ class GenericClassTest {
                 }
             """,
         )
+
+    @TestFactory
+    fun `multiple type parameters`() =
+        compile(
+            """
+                import com.faendir.kotlin.autodsl.AutoDsl
+                @AutoDsl
+                class Entity<T, U>(val a: T, val b: U)
+            """,
+            """
+                import strikt.api.expectThat
+                import strikt.assertions.isEqualTo
+                fun test() {
+                    val entity = entity<String, Int> {
+                        a = "Hi"
+                        b = 1
+                    }
+                    expectThat(entity.a).isEqualTo("Hi")
+                    expectThat(entity.b).isEqualTo(1)
+                }
+            """,
+        )
+
+    @TestFactory
+    fun `nested dsl with type parameter`() =
+        compile(
+            """
+                import com.faendir.kotlin.autodsl.AutoDsl
+                @AutoDsl
+                class Entity<T>(val a: T)
+                @AutoDsl
+                class Root(val entity: Entity<String>)
+            """,
+            """
+                import strikt.api.expectThat
+                import strikt.assertions.isEqualTo
+                fun test() {
+                    expectThat(root {
+                        entity {
+                            a = "Hi"
+                        }
+                    }.entity.a).isEqualTo("Hi")
+                }
+            """,
+        )
+
+    @TestFactory
+    fun `nested dsl with multiple type parameters`() =
+        compile(
+            """
+                import com.faendir.kotlin.autodsl.AutoDsl
+                @AutoDsl
+                class Entity<T, U>(val a: T, val b: U)
+                @AutoDsl
+                class Root(val entity: Entity<String, Int>)
+            """,
+            """
+                import strikt.api.expectThat
+                import strikt.assertions.isEqualTo
+                fun test() {
+                    expectThat(root {
+                        entity {
+                            a = "Hi"
+                            b = 1
+                        }
+                    }.entity.a).isEqualTo("Hi")
+                }
+            """,
+        )
+
+    @TestFactory
+    fun `nested dsl with star projection`() =
+        compile(
+            """
+                import com.faendir.kotlin.autodsl.AutoDsl
+                @AutoDsl
+                class Entity<T>(val a: T)
+                @AutoDsl
+                class Root(val entity: Entity<*>)
+            """,
+            """
+                import strikt.api.expectThat
+                import strikt.assertions.isEqualTo
+                fun test() {
+                    expectThat(root {
+                        entity<String> {
+                            a = "Hi"
+                        }
+                    }.entity.a).isEqualTo("Hi")
+                }
+            """,
+        )
+
+    @TestFactory
+    fun `nested dsl with out projection`() =
+        compile(
+            """
+                import com.faendir.kotlin.autodsl.AutoDsl
+                @AutoDsl
+                class Entity<T>(val a: T)
+                @AutoDsl
+                class Root(val entity: Entity<out String>)
+            """,
+            """
+                import strikt.api.expectThat
+                import strikt.assertions.isEqualTo
+                fun test() {
+                    expectThat(root {
+                        entity {
+                            a = "Hi"
+                        }
+                    }.entity.a).isEqualTo("Hi")
+                }
+            """,
+        )
 }

--- a/processor/src/test/kotlin/com/faendir/kotlin/autodsl/GenericClassTest.kt
+++ b/processor/src/test/kotlin/com/faendir/kotlin/autodsl/GenericClassTest.kt
@@ -212,4 +212,108 @@ class GenericClassTest {
                 }
             """,
         )
+
+    @TestFactory
+    fun `nested dsl with multiple type parameters sets both properties`() =
+        compile(
+            """
+                import com.faendir.kotlin.autodsl.AutoDsl
+                @AutoDsl
+                class Entity<T, U>(val a: T, val b: U)
+                @AutoDsl
+                class Root(val entity: Entity<String, Int>)
+            """,
+            """
+                import strikt.api.expectThat
+                import strikt.assertions.isEqualTo
+                fun test() {
+                    val r = root {
+                        entity {
+                            a = "Hi"
+                            b = 1
+                        }
+                    }
+                    expectThat(r.entity.a).isEqualTo("Hi")
+                    expectThat(r.entity.b).isEqualTo(1)
+                }
+            """,
+        )
+
+    @TestFactory
+    fun `multiple bounds via where clause`() =
+        compile(
+            """
+                import com.faendir.kotlin.autodsl.AutoDsl
+                @AutoDsl
+                class Entity<T>(val a: T) where T : Comparable<T>, T : CharSequence
+            """,
+            """
+                import strikt.api.expectThat
+                import strikt.assertions.isEqualTo
+                fun test() {
+                    expectThat(entity<String> {
+                        a = "Hi"
+                    }.a).isEqualTo("Hi")
+                }
+            """,
+        )
+
+    @TestFactory
+    fun `type parameter unused by any constructor parameter`() =
+        compile(
+            """
+                import com.faendir.kotlin.autodsl.AutoDsl
+                @AutoDsl
+                class Entity<T>(val a: String)
+            """,
+            """
+                import strikt.api.expectThat
+                import strikt.assertions.isEqualTo
+                fun test() {
+                    expectThat(entity<Int> {
+                        a = "Hi"
+                    }.a).isEqualTo("Hi")
+                }
+            """,
+        )
+
+    @TestFactory
+    fun `generic parameter combined with a default value`() =
+        compile(
+            """
+                import com.faendir.kotlin.autodsl.AutoDsl
+                @AutoDsl
+                class Entity<T>(val a: T?, val b: String = "b")
+            """,
+            """
+                import strikt.api.expectThat
+                import strikt.assertions.isEqualTo
+                fun test() {
+                    val e = entity<String> {
+                        a = "Hi"
+                    }
+                    expectThat(e.a).isEqualTo("Hi")
+                    expectThat(e.b).isEqualTo("b")
+                }
+            """,
+        )
+
+    @TestFactory
+    fun `covariant type parameter`() =
+        compile(
+            """
+                import com.faendir.kotlin.autodsl.AutoDsl
+                @AutoDsl
+                class Entity<out T>(val a: T)
+            """,
+            """
+                import strikt.api.expectThat
+                import strikt.assertions.isEqualTo
+                fun test() {
+                    expectThat(entity<String> {
+                        a = "Hi"
+                    }.a).isEqualTo("Hi")
+                }
+            """,
+        )
 }


### PR DESCRIPTION
This PR adds support for generic classes and properties in AutoDsl. It includes a fix for KAPT where type parameter bounds were incorrectly resolved as Object instead of being omitted (equivalent to Any?).\n\nNote: This PR is stacked on top of #115.