### PR TITLE
Map support with array index syntax, and inspection improvements

### DIFF
--- a/inspections/src/main/kotlin/com/faendir/kotlin/autodsl/inspections/DslInspection.kt
+++ b/inspections/src/main/kotlin/com/faendir/kotlin/autodsl/inspections/DslInspection.kt
@@ -2,6 +2,9 @@ package com.faendir.kotlin.autodsl.inspections
 
 import com.faendir.kotlin.autodsl.DslInspect
 import com.faendir.kotlin.autodsl.DslMandatory
+import com.faendir.kotlin.autodsl.shadow.pluralize.pluralize
+import com.faendir.kotlin.autodsl.shadow.pluralize.singularize
+import com.faendir.kotlin.autodsl.shadow.pluralize.utils.Plurality
 import com.intellij.codeInspection.LocalInspectionTool
 import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemDescriptor
@@ -15,7 +18,9 @@ import org.jetbrains.kotlin.analysis.api.KaSession
 import org.jetbrains.kotlin.analysis.api.analyze
 import org.jetbrains.kotlin.analysis.api.annotations.KaAnnotation
 import org.jetbrains.kotlin.analysis.api.annotations.renderAsSourceCode
+import org.jetbrains.kotlin.analysis.api.components.allSupertypes
 import org.jetbrains.kotlin.analysis.api.components.expandedSymbol
+import org.jetbrains.kotlin.analysis.api.components.isClassType
 import org.jetbrains.kotlin.analysis.api.components.isFunctionType
 import org.jetbrains.kotlin.analysis.api.components.isUnitType
 import org.jetbrains.kotlin.analysis.api.components.memberScope
@@ -29,6 +34,8 @@ import org.jetbrains.kotlin.idea.codeinsight.utils.ConvertLambdaToReferenceUtils
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.StandardClassIds
+import org.jetbrains.kotlin.psi.KtArrayAccessExpression
 import org.jetbrains.kotlin.psi.KtBinaryExpression
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
@@ -67,15 +74,15 @@ class DslInspection : LocalInspectionTool() {
         val body = lambda.bodyExpression ?: return
         val present = body.statements.mapNotNull { extractPropertyName(it) }
         mandatory.values.forEach { group ->
-            if (present.none { group.any { prop -> prop.name == it } }) {
+            if (present.none { group.any { prop -> prop.name.singular == it || prop.name.plural == it } }) {
                 holder.registerProblem(
                     lambda.functionLiteral.rBrace!!,
                     if (group.size == 1) {
-                        "Missing property: ${group.first().name}"
+                        "Missing property: ${group.first().name.name}"
                     } else {
-                        "Missing property: One of ${group.joinToString { it.name }}"
+                        "Missing property: One of ${group.joinToString { it.name.name }}"
                     },
-                    *group.map { InsertMissingFix(it.name, it.hasNestedBuilder) }.toTypedArray(),
+                    *group.map { InsertMissingFix(it.name, it.hasNestedBuilder, it.isMap, it.isCollection) }.toTypedArray(),
                 )
             }
         }
@@ -85,7 +92,7 @@ class DslInspection : LocalInspectionTool() {
         when (expression) {
             // Handle assignments: x = value
             is KtBinaryExpression -> {
-                if (expression.operationToken == KtTokens.EQ) {
+                if (expression.operationToken == KtTokens.EQ || expression.operationToken == KtTokens.PLUSEQ) {
                     extractPropertyName(expression.left)
                 } else {
                     null
@@ -108,9 +115,18 @@ class DslInspection : LocalInspectionTool() {
                 expression.getReferencedName()
             }
 
+            // Handle array access: propertyName[index]
+            is KtArrayAccessExpression -> {
+                extractPropertyName(expression.arrayExpression)
+            }
+
             // Handle nested DSL call: propertyName { ... }
             is KtCallExpression -> {
-                expression.getCallReferencedName()
+                if (expression.calleeExpression is KtArrayAccessExpression) {
+                    extractPropertyName(expression.calleeExpression)
+                } else {
+                    expression.getCallReferencedName()
+                }
             }
 
             else -> {
@@ -119,8 +135,10 @@ class DslInspection : LocalInspectionTool() {
         }
 
     class InsertMissingFix(
-        private val missing: String,
+        private val missing: PluralizableName,
         private val nestedBuilder: Boolean,
+        private val isMap: Boolean,
+        private val isCollection: Boolean,
     ) : LocalQuickFix {
         override fun getFamilyName(): String = "Insert missing assignment"
 
@@ -132,18 +150,30 @@ class DslInspection : LocalInspectionTool() {
             if (body != null) {
                 val factory = KtPsiFactory(project)
                 body.add(factory.createNewLine())
-                body.add(factory.createNameIdentifier(missing))
+                if (nestedBuilder && isCollection) {
+                    body.add(factory.createNameIdentifier(missing.singular))
+                } else {
+                    body.add(factory.createNameIdentifier(missing.name))
+                }
+                if (isMap) {
+                    body.add(factory.createExpression("[TODO()]"))
+                    body.add(factory.createEQ())
+                }
                 if (nestedBuilder) {
                     body.add(factory.createWhiteSpace())
                     body.add(factory.createExpression("{ TODO() }"))
                 } else {
-                    body.add(factory.createEQ())
+                    if (isCollection) {
+                        body.add((factory.createExpression("a += b") as KtBinaryExpression).operationReference)
+                    } else if (!isMap) {
+                        body.add(factory.createEQ())
+                    }
                     body.add(factory.createExpression("TODO()"))
                 }
             }
         }
 
-        override fun getName(): String = "Insert assignment for $missing"
+        override fun getName(): String = "Insert assignment for ${missing.name}"
 
         override fun availableInBatchMode(): Boolean = false
     }
@@ -161,29 +191,66 @@ class DslInspection : LocalInspectionTool() {
             descriptors.filter {
                 it is KaPropertySymbol || (it is KaNamedFunctionSymbol && it.isBuilderFunction())
             }
+
         val mandatoryProps =
-            relevantDescriptors.groupBy { it.name?.identifier }.mapNotNull { (name, descriptors) ->
-                if (name == null) return@mapNotNull null
-                val dslMandatoryAnnotation =
-                    descriptors
-                        .filterIsInstance<KaPropertySymbol>()
-                        .firstOrNull()
-                        ?.setter
-                        ?.annotations
-                        ?.get(DSL_MANDATORY)
-                        ?.firstOrNull() ?: return@mapNotNull null
-                val groupName = dslMandatoryAnnotation.findGroup() ?: name
-                val hasNestedBuilder = descriptors.any { it is KaNamedFunctionSymbol }
-                groupName to MandatoryProperty(name, hasNestedBuilder)
-            }
+            relevantDescriptors
+                .groupBy({ it.name?.identifier?.singularize(Plurality.CouldBeEither) }, { d ->
+                    d.name?.identifier?.let {
+                        PluralizableName(it) to
+                            d
+                    }
+                })
+                .mapNotNull { (name, descriptors) ->
+                    if (name == null) return@mapNotNull null
+                    val notNullDescriptors = descriptors.mapNotNull { it }
+                    val dslMandatoryAnnotation =
+                        notNullDescriptors
+                            .map { it.second }
+                            .filterIsInstance<KaPropertySymbol>()
+                            .firstOrNull()
+                            ?.setter
+                            ?.annotations
+                            ?.get(DSL_MANDATORY)
+                            ?.firstOrNull() ?: return@mapNotNull null
+                    val groupName = dslMandatoryAnnotation.findGroup() ?: name
+                    val name = notNullDescriptors.first { it.second is KaPropertySymbol }.first
+                    val hasNestedBuilder = notNullDescriptors.any { it.second is KaNamedFunctionSymbol }
+                    val isMap =
+                        notNullDescriptors.any {
+                            it.second is KaPropertySymbol &&
+                                (
+                                    it.second.returnType.isClassType(StandardClassIds.Map) ||
+                                        it.second.returnType.allSupertypes
+                                            .any { superType -> superType.isClassType(StandardClassIds.Map) }
+                                )
+                        }
+                    val isCollection =
+                        notNullDescriptors.any {
+                            it.second is KaPropertySymbol &&
+                                (
+                                    it.second.returnType.isClassType(StandardClassIds.Collection) ||
+                                        it.second.returnType.allSupertypes
+                                            .any { superType -> superType.isClassType(StandardClassIds.Collection) }
+                                )
+                        }
+                    groupName to MandatoryProperty(name, hasNestedBuilder, isMap, isCollection)
+                }
         return mandatoryProps.groupBy({ it.first }, { it.second })
     }
 
     @OptIn(KaContextParameterApi::class)
     context(_: KaSession)
     private fun KaNamedFunctionSymbol.isBuilderFunction(): Boolean {
-        if (valueParameters.size != 1) return false
-        val parameterType = valueParameters.first().returnType
+        val parameterType =
+            when (valueParameters.size) {
+                1, 2 -> {
+                    valueParameters.last().returnType
+                }
+
+                else -> {
+                    return false
+                }
+            }
         if (!parameterType.isFunctionType) return false
         val typeArguments = (parameterType as KaFunctionType).typeArguments
         if (typeArguments.size != 2) return false
@@ -201,9 +268,19 @@ class DslInspection : LocalInspectionTool() {
             ?.takeIf { it.isNotEmpty() }
 }
 
-data class MandatoryProperty(
+data class PluralizableName(
     val name: String,
+    val singular: String,
+    val plural: String,
+) {
+    constructor(name: String) : this(name, name.singularize(Plurality.CouldBeEither), name.pluralize(Plurality.CouldBeEither))
+}
+
+data class MandatoryProperty(
+    val name: PluralizableName,
     val hasNestedBuilder: Boolean,
+    val isMap: Boolean,
+    val isCollection: Boolean,
 )
 
 private val DSL_INSPECT = ClassId.topLevel(FqName(DslInspect::class.java.name))

--- a/inspections/src/main/kotlin/com/faendir/kotlin/autodsl/shadow/Readme.md
+++ b/inspections/src/main/kotlin/com/faendir/kotlin/autodsl/shadow/Readme.md
@@ -1,0 +1,3 @@
+## Pluralizer
+
+This is a shadow copy of https://github.com/cesarferreira/kotlin-pluralizer, which is included here due to non-availability in maven central.

--- a/inspections/src/main/kotlin/com/faendir/kotlin/autodsl/shadow/pluralize/Pluralize.kt
+++ b/inspections/src/main/kotlin/com/faendir/kotlin/autodsl/shadow/pluralize/Pluralize.kt
@@ -1,0 +1,276 @@
+package com.faendir.kotlin.autodsl.shadow.pluralize
+
+import com.faendir.kotlin.autodsl.shadow.pluralize.utils.Plurality
+import java.util.regex.Pattern
+
+fun String.pluralize(plurality: Plurality = Plurality.Singular): String {
+    if (plurality == Plurality.Plural) return this
+
+    if (plurality == Plurality.Singular) {
+        return this.pluralizer()
+    }
+
+    if (this.singularizer() != this &&
+        this.singularizer() + "s" != this &&
+        this.singularizer().pluralizer() == this &&
+        this.pluralizer() != this
+    ) {
+        return this
+    }
+
+    return this.pluralizer()
+}
+
+fun String.singularize(plurality: Plurality = Plurality.Plural): String {
+    if (plurality == Plurality.Singular) return this
+
+    if (plurality == Plurality.Plural) return this.singularizer()
+
+    if (this.pluralizer() != this &&
+        this + "s" != this.pluralizer() &&
+        this.pluralizer().singularize() == this &&
+        this.singularizer() != this
+    ) {
+        return this
+    }
+
+    return this.singularize()
+}
+
+fun String.pluralize(count: Int): String {
+    if (count > 1) {
+        return this.pluralize(Plurality.Plural)
+    } else {
+        return this.pluralize(Plurality.Singular)
+    }
+}
+
+fun String.singularize(count: Int): String {
+    if (count > 1) {
+        return this.singularize(Plurality.Plural)
+    } else {
+        return this.singularize(Plurality.Singular)
+    }
+}
+
+private fun String.pluralizer(): String {
+    if (unCountable().contains(this.lowercase())) return this
+    val rule = pluralizeRules().last { Pattern.compile(it.component1(), Pattern.CASE_INSENSITIVE).matcher(this).find() }
+    var found = Pattern.compile(rule.component1(), Pattern.CASE_INSENSITIVE).matcher(this).replaceAll(rule.component2())
+    val endsWith = exceptions().firstOrNull { this.endsWith(it.component1()) }
+    if (endsWith != null) found = this.replace(endsWith.component1(), endsWith.component2())
+    val exception = exceptions().firstOrNull { this.equals(it.component1(), true) }
+    if (exception != null) found = exception.component2()
+    return found
+}
+
+private fun String.singularizer(): String {
+    if (unCountable().contains(this.lowercase())) {
+        return this
+    }
+    val exceptions = exceptions().firstOrNull { this.equals(it.component2(), true) }
+
+    if (exceptions != null) {
+        return exceptions.component1()
+    }
+    val endsWith = exceptions().firstOrNull { this.endsWith(it.component2()) }
+
+    if (endsWith != null) return this.replace(endsWith.component2(), endsWith.component1())
+
+    try {
+        if (singularizeRules().count {
+                Pattern.compile(it.component1(), Pattern.CASE_INSENSITIVE).matcher(this).find()
+            } == 0
+        ) {
+            return this
+        }
+        val rule =
+            singularizeRules().last {
+                Pattern.compile(it.component1(), Pattern.CASE_INSENSITIVE).matcher(this).find()
+            }
+        return Pattern.compile(rule.component1(), Pattern.CASE_INSENSITIVE).matcher(this).replaceAll(rule.component2())
+    } catch (ex: IllegalArgumentException) {
+        Exception("Can't singularize this word, could not find a rule to match.")
+    }
+    return this
+}
+
+fun unCountable(): List<String> =
+    listOf(
+        "equipment",
+        "information",
+        "rice",
+        "money",
+        "species",
+        "series",
+        "fish",
+        "sheep",
+        "aircraft",
+        "bison",
+        "flounder",
+        "pliers",
+        "bream",
+        "gallows",
+        "proceedings",
+        "breeches",
+        "graffiti",
+        "rabies",
+        "britches",
+        "headquarters",
+        "salmon",
+        "carp",
+        "herpes",
+        "scissors",
+        "chassis",
+        "high-jinks",
+        "sea-bass",
+        "clippers",
+        "homework",
+        "cod",
+        "innings",
+        "shears",
+        "contretemps",
+        "jackanapes",
+        "corps",
+        "mackerel",
+        "swine",
+        "debris",
+        "measles",
+        "trout",
+        "diabetes",
+        "mews",
+        "tuna",
+        "djinn",
+        "mumps",
+        "whiting",
+        "eland",
+        "news",
+        "wildebeest",
+        "elk",
+        "pincers",
+        "sugar",
+    )
+
+fun exceptions(): List<Pair<String, String>> =
+    listOf(
+        "person" to "people",
+        "man" to "men",
+        "goose" to "geese",
+        "child" to "children",
+        "sex" to "sexes",
+        "move" to "moves",
+        "stadium" to "stadiums",
+        "deer" to "deer",
+        "codex" to "codices",
+        "murex" to "murices",
+        "silex" to "silices",
+        "radix" to "radices",
+        "helix" to "helices",
+        "alumna" to "alumnae",
+        "alga" to "algae",
+        "vertebra" to "vertebrae",
+        "persona" to "personae",
+        "stamen" to "stamina",
+        "foramen" to "foramina",
+        "lumen" to "lumina",
+        "afreet" to "afreeti",
+        "afrit" to "afriti",
+        "efreet" to "efreeti",
+        "cherub" to "cherubim",
+        "goy" to "goyim",
+        "human" to "humans",
+        "lumen" to "lumina",
+        "seraph" to "seraphim",
+        "Alabaman" to "Alabamans",
+        "Bahaman" to "Bahamans",
+        "Burman" to "Burmans",
+        "German" to "Germans",
+        "Hiroshiman" to "Hiroshimans",
+        "Liman" to "Limans",
+        "Nakayaman" to "Nakayamans",
+        "Oklahoman" to "Oklahomans",
+        "Panaman" to "Panamans",
+        "Selman" to "Selmans",
+        "Sonaman" to "Sonamans",
+        "Tacoman" to "Tacomans",
+        "Yakiman" to "Yakimans",
+        "Yokohaman" to "Yokohamans",
+        "Yuman" to "Yumans",
+        "criterion" to "criteria",
+        "perihelion" to "perihelia",
+        "aphelion" to "aphelia",
+        "phenomenon" to "phenomena",
+        "prolegomenon" to "prolegomena",
+        "noumenon" to "noumena",
+        "organon" to "organa",
+        "asyndeton" to "asyndeta",
+        "hyperbaton" to "hyperbata",
+        "foot" to "feet",
+    )
+
+fun pluralizeRules(): List<Pair<String, String>> =
+    listOf(
+        "$" to "s",
+        "s$" to "s",
+        "(ax|test)is$" to "$1es",
+        "us$" to "i",
+        "(octop|vir)us$" to "$1i",
+        "(octop|vir)i$" to "$1i",
+        "(alias|status)$" to "$1es",
+        "(bu)s$" to "$1ses",
+        "(buffal|tomat)o$" to "$1oes",
+        "([ti])um$" to "$1a",
+        "([ti])a$" to "$1a",
+        "sis$" to "ses",
+        "(,:([^f])fe|([lr])f)$" to "$1$2ves",
+        "(hive)$" to "$1s",
+        "([^aeiouy]|qu)y$" to "$1ies",
+        "(x|ch|ss|sh)$" to "$1es",
+        "(matr|vert|ind)ix|ex$" to "$1ices",
+        "([m|l])ouse$" to "$1ice",
+        "([m|l])ice$" to "$1ice",
+        "^(ox)$" to "$1en",
+        "(quiz)$" to "$1zes",
+        "f$" to "ves",
+        "fe$" to "ves",
+        "um$" to "a",
+        "on$" to "a",
+        "tion" to "tions",
+        "sion" to "sions",
+    )
+
+fun singularizeRules(): List<Pair<String, String>> =
+    listOf(
+        "s$" to "",
+        "(s|si|u)s$" to "$1s",
+        "(n)ews$" to "$1ews",
+        "([ti])a$" to "$1um",
+        "((a)naly|(b)a|(d)iagno|(p)arenthe|(p)rogno|(s)ynop|(t)he)ses$" to "$1$2sis",
+        "(^analy)ses$" to "$1sis",
+        "(^analy)sis$" to "$1sis",
+        "([^f])ves$" to "$1fe",
+        "(hive)s$" to "$1",
+        "(tive)s$" to "$1",
+        "([lr])ves$" to "$1f",
+        "([^aeiouy]|qu)ies$" to "$1y",
+        "(s)eries$" to "$1eries",
+        "(m)ovies$" to "$1ovie",
+        "(x|ch|ss|sh)es$" to "$1",
+        "([m|l])ice$" to "$1ouse",
+        "(bus)es$" to "$1",
+        "(o)es$" to "$1",
+        "(shoe)s$" to "$1",
+        "(cris|ax|test)is$" to "$1is",
+        "(cris|ax|test)es$" to "$1is",
+        "(octop|vir)i$" to "$1us",
+        "(octop|vir)us$" to "$1us",
+        "(alias|status)es$" to "$1",
+        "(alias|status)$" to "$1",
+        "^(ox)en" to "$1",
+        "(vert|ind)ices$" to "$1ex",
+        "(matr)ices$" to "$1ix",
+        "(quiz)zes$" to "$1",
+        "a$" to "um",
+        "i$" to "us",
+        "ae$" to "a",
+    )

--- a/inspections/src/main/kotlin/com/faendir/kotlin/autodsl/shadow/pluralize/utils/Plurality.kt
+++ b/inspections/src/main/kotlin/com/faendir/kotlin/autodsl/shadow/pluralize/utils/Plurality.kt
@@ -1,0 +1,7 @@
+package com.faendir.kotlin.autodsl.shadow.pluralize.utils
+
+enum class Plurality {
+    Singular,
+    Plural,
+    CouldBeEither,
+}

--- a/processor/src/main/kotlin/com/faendir/kotlin/autodsl/DslGenerator.kt
+++ b/processor/src/main/kotlin/com/faendir/kotlin/autodsl/DslGenerator.kt
@@ -1,8 +1,10 @@
 package com.faendir.kotlin.autodsl
 
+import com.faendir.kotlin.autodsl.parameter.CollectionType
 import com.faendir.kotlin.autodsl.parameter.Parameter
 import com.faendir.kotlin.autodsl.parameter.ParameterFactory
 import com.google.devtools.ksp.symbol.ClassKind
+import com.squareup.kotlinpoet.ANY
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.BOOLEAN
 import com.squareup.kotlinpoet.BYTE
@@ -13,9 +15,11 @@ import com.squareup.kotlinpoet.FLOAT
 import com.squareup.kotlinpoet.INT
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.LONG
+import com.squareup.kotlinpoet.LambdaTypeName
 import com.squareup.kotlinpoet.ParameterizedTypeName
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.SHORT
+import com.squareup.kotlinpoet.STAR
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeVariableName
 import com.squareup.kotlinpoet.WildcardTypeName
@@ -24,12 +28,19 @@ import com.squareup.kotlinpoet.joinToCode
 import io.github.enjoydambience.kotlinbard.TypeSpecBuilder
 import io.github.enjoydambience.kotlinbard.addAnnotation
 import io.github.enjoydambience.kotlinbard.addClass
+import io.github.enjoydambience.kotlinbard.addCode
 import io.github.enjoydambience.kotlinbard.addFunction
 import io.github.enjoydambience.kotlinbard.addKdoc
+import io.github.enjoydambience.kotlinbard.addParameter
 import io.github.enjoydambience.kotlinbard.addProperty
 import io.github.enjoydambience.kotlinbard.buildFile
 import io.github.enjoydambience.kotlinbard.codeFmt
+import io.github.enjoydambience.kotlinbard.controlFlow
+import io.github.enjoydambience.kotlinbard.getter
+import io.github.enjoydambience.kotlinbard.`if`
 import io.github.enjoydambience.kotlinbard.nullable
+import io.github.enjoydambience.kotlinbard.primaryConstructor
+import io.github.enjoydambience.kotlinbard.setter
 import java.util.Locale
 import kotlin.jvm.internal.DefaultConstructorMarker
 import kotlin.properties.Delegates
@@ -137,6 +148,124 @@ class DslGenerator<A, T : A, C : A, P : A>(
                         }
                     }
                 }
+                if (parameters.any { it.hasNestedDsl && it.collectionType is CollectionType.MapType }) {
+                    addClass("BuilderMapProxy") {
+                        addModifiers(KModifier.PRIVATE)
+                        val kType = TypeVariableName("K")
+                        val vType = TypeVariableName("V")
+                        val bType = TypeVariableName("B")
+                        addTypeVariable(kType)
+                        addTypeVariable(vType)
+                        addTypeVariable(bType)
+
+                        val delegateField = "delegate"
+                        val factoryField = "builderFactory"
+                        val executorField = "builderExecutor"
+                        val setterField = "setter"
+
+                        primaryConstructor {
+                            addParameter(delegateField, Map::class.asClassName().parameterizedBy(kType, vType))
+                            addParameter(factoryField, LambdaTypeName.get(returnType = bType))
+                            addParameter(executorField, LambdaTypeName.get(parameters = arrayOf(bType), returnType = vType))
+                            addParameter(
+                                setterField,
+                                LambdaTypeName.get(
+                                    parameters = arrayOf(Map::class.asClassName().parameterizedBy(kType, vType)),
+                                    returnType = Unit::class.asClassName(),
+                                ),
+                            )
+                        }
+
+                        addProperty(delegateField, Map::class.asClassName().parameterizedBy(kType, vType), KModifier.PRIVATE) {
+                            initializer(delegateField)
+                        }
+                        addProperty(factoryField, LambdaTypeName.get(returnType = bType), KModifier.PRIVATE) {
+                            initializer(factoryField)
+                        }
+                        addProperty(executorField, LambdaTypeName.get(parameters = arrayOf(bType), returnType = vType), KModifier.PRIVATE) {
+                            initializer(executorField)
+                        }
+                        addProperty(
+                            setterField,
+                            LambdaTypeName.get(
+                                parameters = arrayOf(Map::class.asClassName().parameterizedBy(kType, vType)),
+                                returnType = Unit::class.asClassName(),
+                            ),
+                            KModifier.PRIVATE,
+                        ) {
+                            initializer(setterField)
+                        }
+
+                        addSuperinterface(Map::class.asClassName().parameterizedBy(kType, vType), "delegate")
+
+                        addFunction("put") {
+                            addParameter("key", kType)
+                            val blockType = bType.asLambdaReceiver()
+                            addParameter("block", blockType)
+                            addCode {
+                                addStatement("val builder = %L()", factoryField)
+                                addStatement("builder.block()")
+                                addStatement("val result = %L(builder)", executorField)
+                                addStatement("%1L(%2L + (key to result))", setterField, delegateField)
+                            }
+                        }
+                        addFunction("put") {
+                            addParameter("key", kType)
+                            addParameter("value", vType)
+                            addCode {
+                                addStatement("%1L(%2L + (key to value))", setterField, delegateField)
+                            }
+                        }
+                    }
+                }
+                if (parameters.any { !it.hasNestedDsl && it.collectionType is CollectionType.MapType }) {
+                    addClass("MapProxy") {
+                        addModifiers(KModifier.PRIVATE)
+                        val kType = TypeVariableName("K")
+                        val vType = TypeVariableName("V")
+                        addTypeVariable(kType)
+                        addTypeVariable(vType)
+
+                        val delegateField = "delegate"
+                        val setterField = "setter"
+
+                        primaryConstructor {
+                            addParameter(delegateField, Map::class.asClassName().parameterizedBy(kType, vType))
+                            addParameter(
+                                setterField,
+                                LambdaTypeName.get(
+                                    parameters = arrayOf(Map::class.asClassName().parameterizedBy(kType, vType)),
+                                    returnType = Unit::class.asClassName(),
+                                ),
+                            )
+                        }
+
+                        addProperty(delegateField, Map::class.asClassName().parameterizedBy(kType, vType), KModifier.PRIVATE) {
+                            initializer(delegateField)
+                        }
+                        addProperty(
+                            setterField,
+                            LambdaTypeName.get(
+                                parameters = arrayOf(Map::class.asClassName().parameterizedBy(kType, vType)),
+                                returnType = Unit::class.asClassName(),
+                            ),
+                            KModifier.PRIVATE,
+                        ) {
+                            initializer(setterField)
+                        }
+
+                        addSuperinterface(Map::class.asClassName().parameterizedBy(kType, vType), "delegate")
+
+                        addFunction("put") {
+                            addParameter("key", kType)
+                            addParameter("value", vType)
+                            addCode {
+                                addStatement("%1L(%2L + (key to value))", setterField, delegateField)
+                            }
+                        }
+                    }
+                }
+                val operatorCollisions = mutableSetOf<TypeName>()
                 for (parameter in parameters) {
                     addParameterProperty(parameter, entityClass)
                     addParameterBuilderStyleSetter(parameter, builderType, entityClass)
@@ -144,6 +273,9 @@ class DslGenerator<A, T : A, C : A, P : A>(
                         addParameterBuilderStyleVarargSetter(parameter, builderType, entityClass)
                         if (parameter.hasNestedDsl) {
                             addParameterNestedAdder(parameter)
+                        }
+                        if (operatorCollisions.add(parameter.typeName)) {
+                            addParameterOperatorAdder(parameter)
                         }
                     } else if (parameter.hasNestedDsl) {
                         addParameterNestedSetter(parameter)
@@ -154,7 +286,12 @@ class DslGenerator<A, T : A, C : A, P : A>(
                     parameters.filter { it.isMandatory }.groupBy { it.group }.forEach { (_, parameters) ->
                         addStatement(
                             "check(%L)·{ \"%L·must·be·assigned.\" }",
-                            parameters.map { "%L != null".codeFmt(it.name) }.joinToCode(" || "),
+                            parameters
+                                .map {
+                                    "%L != null".codeFmt(
+                                        if (it.collectionType is CollectionType.MapType) "_${it.name}" else it.name,
+                                    )
+                                }.joinToCode(" || "),
                             parameters.joinToString(separator = ",·", prefix = if (parameters.size > 1) "One·of·" else "") { it.name },
                         )
                     }
@@ -178,6 +315,7 @@ class DslGenerator<A, T : A, C : A, P : A>(
                             parameters
                                 .map {
                                     when {
+                                        it.collectionType is CollectionType.MapType -> "_%L"
                                         it.typeName.isNullable -> "%L"
                                         it.typeName == BOOLEAN -> "%L ?: false"
                                         it.typeName == BYTE -> "%L ?: 0"
@@ -196,7 +334,12 @@ class DslGenerator<A, T : A, C : A, P : A>(
                         addStatement(
                             "return %T(%L)",
                             entityClass,
-                            parameters.map { (if (it.typeName.isNullable) "%L" else "%L!!").codeFmt(it.name) }.joinToCode(),
+                            parameters
+                                .map {
+                                    (if (it.typeName.isNullable) "%L" else "%L!!").codeFmt(
+                                        if (it.collectionType is CollectionType.MapType) "_${it.name}" else it.name,
+                                    )
+                                }.joinToCode(),
                         )
                     }
                 }
@@ -238,13 +381,33 @@ class DslGenerator<A, T : A, C : A, P : A>(
     private fun TypeSpecBuilder.addParameterNestedAdder(parameter: Parameter) =
         addFunction(parameter.collectionType!!.singular) {
             addModifiers(KModifier.INLINE)
-            val elementType = (parameter.typeName as ParameterizedTypeName).typeArguments.first()
-            val nestedBuilderType = elementType.withBuilderSuffix()
-            addParameter("initializer", nestedBuilderType.asLambdaReceiver())
-            addStatement("val result = %T().apply(initializer).build()", nestedBuilderType)
-            addStatement("%1L = %1L?.plus(result) ?: %2L(result)", parameter.name, parameter.collectionType.createFunction)
-            addStatement("return result")
-            returns(elementType.nonnull)
+            if (parameter.collectionType is CollectionType.MapType) {
+                val keyType = (parameter.typeName as ParameterizedTypeName).typeArguments.getOrNull(0) ?: ANY
+                val valueType = parameter.typeName.typeArguments.getOrNull(1) ?: ANY
+                val nestedBuilderType = valueType.withBuilderSuffix()
+                addParameter("key", keyType)
+                addParameter("initializer", nestedBuilderType.asLambdaReceiver())
+                addStatement("val result = %T().apply(initializer).build()", nestedBuilderType)
+                addStatement(
+                    "%1L = %1L?.plus(key to result) ?: %2L(key to result)",
+                    parameter.name,
+                    parameter.collectionType.createFunction,
+                )
+                addStatement("return result")
+                returns(valueType.nonnull)
+            } else {
+                val elementType = (parameter.typeName as ParameterizedTypeName).typeArguments.first()
+                val nestedBuilderType = elementType.withBuilderSuffix()
+                addParameter("initializer", nestedBuilderType.asLambdaReceiver())
+                addStatement("val result = %T().apply(initializer).build()", nestedBuilderType)
+                addStatement(
+                    "%1L = %1L?.plus(result) ?: %2L(result)",
+                    parameter.name,
+                    parameter.collectionType.createFunction,
+                )
+                addStatement("return result")
+                returns(elementType.nonnull)
+            }
         }
 
     private fun TypeSpecBuilder.addParameterBuilderStyleVarargSetter(
@@ -252,13 +415,26 @@ class DslGenerator<A, T : A, C : A, P : A>(
         builderType: TypeName,
         entityClass: ClassName,
     ) = addFunction("with${parameter.name.replaceFirstChar { it.uppercase() }}") {
-        val elementType =
-            (parameter.typeName as ParameterizedTypeName).typeArguments.first().let {
-                if (it is WildcardTypeName) it.outTypes.first() else it
-            }
         returns(builderType)
-        addParameter(parameter.name, elementType, KModifier.VARARG)
-        addStatement("this.%1L·= %1L.%2L()", parameter.name, parameter.collectionType!!.convertFunction)
+        if (parameter.collectionType is CollectionType.MapType) {
+            val keyType =
+                (parameter.typeName as ParameterizedTypeName).typeArguments[0].let {
+                    if (it is WildcardTypeName) it.outTypes.first() else it
+                }
+            val valueType =
+                parameter.typeName.typeArguments[1].let {
+                    if (it is WildcardTypeName) it.outTypes.first() else it
+                }
+            addParameter(parameter.name, Pair::class.asClassName().parameterizedBy(keyType, valueType), KModifier.VARARG)
+            addStatement("this.%1L·= %1L.%2L()", parameter.name, parameter.collectionType.convertFunction)
+        } else {
+            val elementType =
+                (parameter.typeName as ParameterizedTypeName).typeArguments.first().let {
+                    if (it is WildcardTypeName) it.outTypes.first() else it
+                }
+            addParameter(parameter.name, elementType, KModifier.VARARG)
+            addStatement("this.%1L·= %1L.%2L()", parameter.name, parameter.collectionType!!.convertFunction)
+        }
         addStatement("return this")
         addKdoc {
             parameter.doc?.let { add("%L\n\n", it) }
@@ -284,27 +460,296 @@ class DslGenerator<A, T : A, C : A, P : A>(
     private fun TypeSpecBuilder.addParameterProperty(
         parameter: Parameter,
         entityClass: ClassName,
-    ) = addProperty(parameter.name, parameter.typeName.nullable) {
-        mutable(true)
-        if (parameter.hasDefault) {
-            delegate(
-                "%1T.observable(null)·{·_, _, _·-> %2L·= %2L and %3L }",
-                Delegates::class.asClassName(),
-                DEFAULTS_BITFLAGS_FIELD_NAME + (parameter.index / 32),
-                (1 shl parameter.index % 32).inv(),
-            )
+    ) {
+        if (parameter.collectionType is CollectionType.MapType) {
+            val safeType =
+                parameter.typeName
+                    .let { type ->
+                        if (type is ParameterizedTypeName) {
+                            val safeArgs =
+                                type.typeArguments.map {
+                                    if (it == STAR) Any::class.asClassName().nullable else it
+                                }
+                            type.rawType.parameterizedBy(safeArgs)
+                        } else {
+                            type
+                        }
+                    }.withoutVariance() as ParameterizedTypeName
+            val keyType = safeType.typeArguments[0]
+            val valueType = safeType.typeArguments[1]
+            val valueBuilderType = valueType.withBuilderSuffix()
+            val backingFieldName = "_${parameter.name}"
+            addProperty(backingFieldName, parameter.typeName.nullable, KModifier.PRIVATE) {
+                mutable(true)
+                if (parameter.hasDefault) {
+                    delegate(
+                        "%1T.observable(null)·{·_, _, _·-> %2L·= %2L and %3L }",
+                        Delegates::class.asClassName(),
+                        DEFAULTS_BITFLAGS_FIELD_NAME + (parameter.index / 32),
+                        (1 shl parameter.index % 32).inv(),
+                    )
+                } else {
+                    initializer("null")
+                }
+            }
+
+            addProperty(parameter.name, parameter.typeName.nullable) {
+                mutable(true)
+                getter {
+                    if (parameter.hasNestedDsl) {
+                        addStatement(
+                            "return %1T(%2L ?: emptyMap(), { %3T() }, { it.build() }) { %2L = it }",
+                            ClassName("", "BuilderMapProxy").parameterizedBy(keyType, valueType, valueBuilderType),
+                            backingFieldName,
+                            valueBuilderType,
+                        )
+                    } else {
+                        addStatement(
+                            "return %1T(%2L ?: emptyMap()) { %2L = it }",
+                            ClassName("", "MapProxy").parameterizedBy(keyType, valueType),
+                            backingFieldName,
+                        )
+                    }
+                }
+
+                setter {
+                    addParameter("value", parameter.typeName.nullable)
+                    addStatement("%L = value", backingFieldName)
+                }
+
+                if (parameter.isMandatory) {
+                    addAnnotation(DslMandatory::class) {
+                        useSiteTarget(AnnotationSpec.UseSiteTarget.SET)
+                        addMember("group = %S", parameter.group)
+                    }
+                }
+                addKdoc {
+                    parameter.doc?.let { add("%L\n\n", it) }
+                    add("@see %T.%L", entityClass, parameter.name)
+                }
+            }
         } else {
-            initializer("null")
-        }
-        if (parameter.isMandatory) {
-            addAnnotation(DslMandatory::class) {
-                useSiteTarget(AnnotationSpec.UseSiteTarget.SET)
-                addMember("group = %S", parameter.group)
+            addProperty(parameter.name, parameter.typeName.nullable) {
+                mutable(true)
+                if (parameter.hasDefault) {
+                    delegate(
+                        "%1T.observable(null)·{·_, _, _·-> %2L·= %2L and %3L }",
+                        Delegates::class.asClassName(),
+                        DEFAULTS_BITFLAGS_FIELD_NAME + (parameter.index / 32),
+                        (1 shl parameter.index % 32).inv(),
+                    )
+                } else {
+                    initializer("null")
+                }
+                if (parameter.isMandatory) {
+                    addAnnotation(DslMandatory::class) {
+                        useSiteTarget(AnnotationSpec.UseSiteTarget.SET)
+                        addMember("group = %S", parameter.group)
+                    }
+                }
+                parameter.doc?.let { addKdoc(it) }
+                addKdoc {
+                    parameter.doc?.let { add("%L\n\n", it) }
+                    add("@see %T.%L", entityClass, parameter.name)
+                }
             }
         }
-        addKdoc {
-            parameter.doc?.let { add("%L\n\n", it) }
-            add("@see %T.%L", entityClass, parameter.name)
+    }
+
+    private fun TypeSpecBuilder.addParameterOperatorAdder(parameter: Parameter) {
+        val safeType =
+            parameter.typeName
+                .let { type ->
+                    if (type is ParameterizedTypeName) {
+                        val safeArgs =
+                            type.typeArguments.map {
+                                if (it == STAR) Any::class.asClassName().nullable else it
+                            }
+                        type.rawType.parameterizedBy(safeArgs)
+                    } else {
+                        type
+                    }
+                }.withoutVariance() as ParameterizedTypeName
+        if (parameter.collectionType is CollectionType.MapType) {
+            val keyType = safeType.typeArguments[0]
+            val valueType = safeType.typeArguments[1]
+            val blockType = valueType.withBuilderSuffix().asLambdaReceiver()
+            addFunction("plus") {
+                receiver(safeType.nullable)
+                returns(safeType)
+                addAnnotation(JvmName::class) {
+                    addMember("%S", "add${parameter.collectionType.singular.replaceFirstChar { it.uppercase() }}")
+                }
+                addModifiers(KModifier.OPERATOR)
+                addParameter("pair", Pair::class.asClassName().parameterizedBy(keyType, valueType))
+                addCode {
+                    controlFlow(
+                        "return %L",
+                        parameter.collectionType.builderFunction,
+                    ) {
+                        `if`("this@plus != null") {
+                            addStatement("putAll(this@plus)")
+                        }
+                        addStatement("put(pair.first, pair.second)")
+                    }
+                }
+            }
+            addFunction("plus") {
+                receiver(safeType.nullable)
+                returns(safeType)
+                addAnnotation(JvmName::class) {
+                    addMember("%S", "addAll${parameter.collectionType.singular.replaceFirstChar { it.uppercase() }}")
+                }
+                addModifiers(KModifier.OPERATOR)
+                addParameter("value", safeType)
+                addCode {
+                    controlFlow(
+                        "return %L",
+                        parameter.collectionType.builderFunction,
+                    ) {
+                        `if`("this@plus != null") {
+                            addStatement("putAll(this@plus)")
+                        }
+                        addStatement("putAll(value)")
+                    }
+                }
+            }
+            if (parameter.hasNestedDsl) {
+                addFunction("set") {
+                    receiver(safeType.nullable)
+                    addAnnotation(JvmName::class) {
+                        addMember("%S", "putBuilder${parameter.collectionType.singular.replaceFirstChar { it.uppercase() }}")
+                    }
+                    addAnnotation(Suppress::class) {
+                        addMember("%S", "UNCHECKED_CAST")
+                    }
+                    addModifiers(KModifier.OPERATOR)
+                    addParameter("key", keyType)
+                    addParameter("block", blockType)
+                    addCode {
+                        `if`("this@set is %T", ClassName("", "BuilderMapProxy").parameterizedBy(STAR, STAR, STAR)) {
+                            addStatement(
+                                "(this@set as %T<%T, %T, %T>).put(key, block)",
+                                ClassName("", "BuilderMapProxy"),
+                                keyType,
+                                valueType,
+                                valueType.withBuilderSuffix(),
+                            )
+                        }
+                    }
+                }
+                addFunction("set") {
+                    receiver(safeType.nullable)
+                    addAnnotation(JvmName::class) {
+                        addMember("%S", "put${parameter.collectionType.singular.replaceFirstChar { it.uppercase() }}")
+                    }
+                    addAnnotation(Suppress::class) {
+                        addMember("%S", "UNCHECKED_CAST")
+                    }
+                    addModifiers(KModifier.OPERATOR)
+                    addParameter("key", keyType)
+                    addParameter("value", valueType)
+                    addCode {
+                        `if`("this@set is %T", ClassName("", "BuilderMapProxy").parameterizedBy(STAR, STAR, STAR)) {
+                            addStatement(
+                                "(this@set as %T<%T, %T, %T>).put(key, value)",
+                                ClassName("", "BuilderMapProxy"),
+                                keyType,
+                                valueType,
+                                valueType.withBuilderSuffix(),
+                            )
+                        }
+                    }
+                }
+                addFunction("put") {
+                    receiver(safeType.withMutablePrefix())
+                    addAnnotation(JvmName::class) {
+                        addMember("%S", "putMutableBuilder${parameter.collectionType.singular.replaceFirstChar { it.uppercase() }}")
+                    }
+                    addParameter("key", keyType)
+                    addParameter("block", blockType)
+                    addCode {
+                        addStatement("this@put[key] = %T().apply(block).build()", valueType.withBuilderSuffix())
+                    }
+                }
+            } else {
+                addFunction("set") {
+                    receiver(safeType.nullable)
+                    addAnnotation(JvmName::class) {
+                        addMember("%S", "put${parameter.collectionType.singular.replaceFirstChar { it.uppercase() }}")
+                    }
+                    addAnnotation(Suppress::class) {
+                        addMember("%S", "UNCHECKED_CAST")
+                    }
+                    addModifiers(KModifier.OPERATOR)
+                    addParameter("key", keyType)
+                    addParameter("value", valueType)
+                    addCode {
+                        `if`("this@set is %T", ClassName("", "MapProxy").parameterizedBy(STAR, STAR)) {
+                            addStatement(
+                                "(this@set as %T<%T, %T>).put(key, value)",
+                                ClassName("", "MapProxy"),
+                                keyType,
+                                valueType,
+                            )
+                        }
+                    }
+                }
+            }
+        } else {
+            val elementType = safeType.typeArguments.first()
+            addFunction("plus") {
+                receiver(safeType.nullable)
+                returns(safeType)
+                addAnnotation(JvmName::class) {
+                    addMember("%S", "add${parameter.collectionType!!.singular.replaceFirstChar { it.uppercase() }}")
+                }
+                addModifiers(KModifier.OPERATOR)
+                addParameter("value", elementType)
+                addCode {
+                    controlFlow(
+                        "return %L",
+                        parameter.collectionType!!.builderFunction,
+                    ) {
+                        `if`("this@plus != null") {
+                            addStatement("addAll(this@plus)")
+                        }
+                        addStatement("add(value)")
+                    }
+                }
+            }
+            addFunction("plus") {
+                receiver(safeType.nullable)
+                returns(safeType)
+                addAnnotation(JvmName::class) {
+                    addMember("%S", "addAll${parameter.collectionType!!.singular.replaceFirstChar { it.uppercase() }}")
+                }
+                addModifiers(KModifier.OPERATOR)
+                addParameter("value", safeType)
+                addCode {
+                    controlFlow(
+                        "return %L",
+                        parameter.collectionType!!.builderFunction,
+                    ) {
+                        `if`("this@plus != null") {
+                            addStatement("addAll(this@plus)")
+                        }
+                        addStatement("addAll(value)")
+                    }
+                }
+            }
+            if (parameter.hasNestedDsl) {
+                addFunction("add") {
+                    receiver(safeType.withMutablePrefix())
+                    addAnnotation(JvmName::class) {
+                        addMember("%S", "addMutableBuilder${parameter.collectionType!!.singular.replaceFirstChar { it.uppercase() }}")
+                    }
+                    addParameter("block", elementType.withBuilderSuffix().asLambdaReceiver())
+                    addCode {
+                        addStatement("this@add.add(%T().apply(block).build())", elementType.withBuilderSuffix())
+                    }
+                }
+            }
         }
     }
 }

--- a/processor/src/main/kotlin/com/faendir/kotlin/autodsl/DslGenerator.kt
+++ b/processor/src/main/kotlin/com/faendir/kotlin/autodsl/DslGenerator.kt
@@ -25,6 +25,7 @@ import com.squareup.kotlinpoet.TypeVariableName
 import com.squareup.kotlinpoet.WildcardTypeName
 import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.joinToCode
+import io.github.enjoydambience.kotlinbard.FileSpecBuilder
 import io.github.enjoydambience.kotlinbard.TypeSpecBuilder
 import io.github.enjoydambience.kotlinbard.addAnnotation
 import io.github.enjoydambience.kotlinbard.addClass
@@ -360,6 +361,50 @@ class DslGenerator<A, T : A, C : A, P : A>(
                 addStatement("return %T().apply(initializer).build()", builderType)
                 returns(entityType)
             }
+            addFunction("add") {
+                addModifiers(KModifier.INLINE)
+                for (typeParam in entityTypeParameters) {
+                    addTypeVariable(typeParam)
+                }
+                receiver(Collection::class.asClassName().withMutablePrefix().parameterizedBy(entityType))
+                addParameter("builder", builderType.asLambdaReceiver())
+                addStatement("return this@add.add(%T().apply(builder).build())", builderType)
+                returns(Boolean::class.asClassName())
+            }
+            addFunction("plusAssign") {
+                addModifiers(KModifier.INLINE, KModifier.OPERATOR)
+                for (typeParam in entityTypeParameters) {
+                    addTypeVariable(typeParam)
+                }
+                receiver(Collection::class.asClassName().withMutablePrefix().parameterizedBy(entityType))
+                addParameter("builder", builderType.asLambdaReceiver())
+                addStatement("this@plusAssign += %T().apply(builder).build()", builderType)
+            }
+            addFunction("put") {
+                addModifiers(KModifier.INLINE)
+                val key = TypeVariableName("KEY")
+                addTypeVariable(key)
+                for (typeParam in entityTypeParameters) {
+                    addTypeVariable(typeParam)
+                }
+                receiver(Map::class.asClassName().withMutablePrefix().parameterizedBy(key, entityType))
+                addParameter("key", key)
+                addParameter("builder", builderType.asLambdaReceiver())
+                addStatement("return this@put.put(key, %T().apply(builder).build())", builderType)
+                returns(entityType.nullable)
+            }
+            addFunction("set") {
+                addModifiers(KModifier.INLINE, KModifier.OPERATOR)
+                val key = TypeVariableName("KEY")
+                addTypeVariable(key)
+                for (typeParam in entityTypeParameters) {
+                    addTypeVariable(typeParam)
+                }
+                receiver(Map::class.asClassName().withMutablePrefix().parameterizedBy(key, entityType))
+                addParameter("key", key)
+                addParameter("builder", builderType.asLambdaReceiver())
+                addStatement("this@set.put(key, builder)")
+            }
         }.writeTo(entity, codeGenerator)
         return true
     }
@@ -661,17 +706,6 @@ class DslGenerator<A, T : A, C : A, P : A>(
                         }
                     }
                 }
-                addFunction("put") {
-                    receiver(safeType.withMutablePrefix())
-                    addAnnotation(JvmName::class) {
-                        addMember("%S", "putMutableBuilder${parameter.collectionType.singular.replaceFirstChar { it.uppercase() }}")
-                    }
-                    addParameter("key", keyType)
-                    addParameter("block", blockType)
-                    addCode {
-                        addStatement("this@put[key] = %T().apply(block).build()", valueType.withBuilderSuffix())
-                    }
-                }
             } else {
                 addFunction("set") {
                     receiver(safeType.nullable)
@@ -735,18 +769,6 @@ class DslGenerator<A, T : A, C : A, P : A>(
                             addStatement("addAll(this@plus)")
                         }
                         addStatement("addAll(value)")
-                    }
-                }
-            }
-            if (parameter.hasNestedDsl) {
-                addFunction("add") {
-                    receiver(safeType.withMutablePrefix())
-                    addAnnotation(JvmName::class) {
-                        addMember("%S", "addMutableBuilder${parameter.collectionType!!.singular.replaceFirstChar { it.uppercase() }}")
-                    }
-                    addParameter("block", elementType.withBuilderSuffix().asLambdaReceiver())
-                    addCode {
-                        addStatement("this@add.add(%T().apply(block).build())", elementType.withBuilderSuffix())
                     }
                 }
             }

--- a/processor/src/main/kotlin/com/faendir/kotlin/autodsl/KotlinPoetUtils.kt
+++ b/processor/src/main/kotlin/com/faendir/kotlin/autodsl/KotlinPoetUtils.kt
@@ -91,11 +91,20 @@ fun TypeName.withoutAnnotations(): TypeName =
 
 fun ClassName.withBuilderSuffix() = ClassName(packageName, "${simpleNames.joinToString("")}Builder")
 
-fun TypeName.withBuilderSuffix() = toRawType().withBuilderSuffix()
+fun TypeName.withBuilderSuffix(): TypeName =
+    when (this) {
+        is ParameterizedTypeName -> rawType.withBuilderSuffix().parameterizedBy(typeArguments)
+        is ClassName -> withBuilderSuffix()
+        else -> toRawType().withBuilderSuffix() // Fallback for other TypeName types, though unlikely to be reached for main classes
+    }
 
-fun ParameterizedTypeName.withMutablePrefix() =
-    toRawType()
-        .let { ClassName(it.packageName, "Mutable${it.simpleNames.joinToString("")}") }
-        .parameterizedBy(typeArguments)
+fun ClassName.withMutablePrefix() = ClassName(packageName, "Mutable${simpleNames.joinToString("")}")
+
+fun TypeName.withMutablePrefix(): TypeName =
+    when (this) {
+        is ParameterizedTypeName -> rawType.withMutablePrefix().parameterizedBy(typeArguments)
+        is ClassName -> withMutablePrefix()
+        else -> toRawType().withMutablePrefix() // Fallback for other TypeName types, though unlikely to be reached for main classes
+    }
 
 fun TypeName.asLambdaReceiver() = LambdaTypeName.get(receiver = this, returnType = Unit::class.asClassName())

--- a/processor/src/main/kotlin/com/faendir/kotlin/autodsl/KotlinPoetUtils.kt
+++ b/processor/src/main/kotlin/com/faendir/kotlin/autodsl/KotlinPoetUtils.kt
@@ -1,5 +1,6 @@
 package com.faendir.kotlin.autodsl
 
+import com.squareup.kotlinpoet.ANY
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.LambdaTypeName
 import com.squareup.kotlinpoet.ParameterizedTypeName
@@ -21,6 +22,29 @@ fun TypeName.toRawType(): ClassName =
         is LambdaTypeName -> ClassName("kotlin", "Function${(if (receiver != null) 1 else 0) + parameters.size}")
         is TypeVariableName -> Any::class.asClassName()
         else -> throw IllegalArgumentException("Unsupported conversion to raw type from $this")
+    }
+
+fun TypeName.withoutVariance(): TypeName =
+    when (this) {
+        is ParameterizedTypeName -> {
+            val newArgs =
+                typeArguments.map { arg ->
+                    if (arg is WildcardTypeName) {
+                        arg.inTypes.firstOrNull() ?: arg.outTypes.firstOrNull() ?: ANY
+                    } else {
+                        arg
+                    }
+                }
+            this.rawType.parameterizedBy(newArgs)
+        }
+
+        is TypeVariableName -> {
+            TypeVariableName(name, bounds).copy(nullable = this.isNullable, annotations = this.annotations, tags = this.tags)
+        }
+
+        else -> {
+            this
+        }
     }
 
 fun TypeName.withoutAnnotations(): TypeName =
@@ -68,5 +92,10 @@ fun TypeName.withoutAnnotations(): TypeName =
 fun ClassName.withBuilderSuffix() = ClassName(packageName, "${simpleNames.joinToString("")}Builder")
 
 fun TypeName.withBuilderSuffix() = toRawType().withBuilderSuffix()
+
+fun ParameterizedTypeName.withMutablePrefix() =
+    toRawType()
+        .let { ClassName(it.packageName, "Mutable${it.simpleNames.joinToString("")}") }
+        .parameterizedBy(typeArguments)
 
 fun TypeName.asLambdaReceiver() = LambdaTypeName.get(receiver = this, returnType = Unit::class.asClassName())

--- a/processor/src/main/kotlin/com/faendir/kotlin/autodsl/parameter/Parameter.kt
+++ b/processor/src/main/kotlin/com/faendir/kotlin/autodsl/parameter/Parameter.kt
@@ -18,14 +18,19 @@ class Parameter(
 
 sealed class CollectionType(
     val createFunction: String,
+    val builderFunction: String,
     val convertFunction: String,
     val singular: String,
 ) {
     class ListType(
         singular: String,
-    ) : CollectionType("listOf", "toList", singular)
+    ) : CollectionType("listOf", "buildList", "toList", singular)
 
     class SetType(
         singular: String,
-    ) : CollectionType("setOf", "toSet", singular)
+    ) : CollectionType("setOf", "buildSet", "toSet", singular)
+
+    class MapType(
+        singular: String,
+    ) : CollectionType("mapOf", "buildMap", "toMap", singular)
 }

--- a/processor/src/main/kotlin/com/faendir/kotlin/autodsl/parameter/ParameterFactory.kt
+++ b/processor/src/main/kotlin/com/faendir/kotlin/autodsl/parameter/ParameterFactory.kt
@@ -6,6 +6,7 @@ import com.faendir.kotlin.autodsl.AutoDslRequired
 import com.faendir.kotlin.autodsl.AutoDslSingular
 import com.faendir.kotlin.autodsl.SourceInfoResolver
 import com.faendir.kotlin.autodsl.parameter.CollectionType.ListType
+import com.faendir.kotlin.autodsl.parameter.CollectionType.MapType
 import com.faendir.kotlin.autodsl.parameter.CollectionType.SetType
 import com.faendir.kotlin.autodsl.toRawType
 import com.shadow.pluralize.singularize
@@ -18,6 +19,7 @@ class ParameterFactory<A, T : A, C : A, P : A>(
 ) : SourceInfoResolver<A, T, C, P> by resolver {
     private val set = Set::class.asClassName()
     private val list = List::class.asClassName()
+    private val map = Map::class.asClassName()
     private val collection = Collection::class.asClassName()
     private val iterable = Iterable::class.asClassName()
 
@@ -36,8 +38,12 @@ class ParameterFactory<A, T : A, C : A, P : A>(
                     }
 
                     list, collection, iterable -> {
-                        parameter.hasAnnotatedTypeArgument(AutoDsl::class) to
-                            ListType(findSingular(parameter, index))
+                        parameter.hasAnnotatedTypeArgument(AutoDsl::class) to ListType(findSingular(parameter, index))
+                    }
+
+                    map -> {
+                        (parameter.hasAnnotatedTypeArgument(AutoDsl::class) || parameter.hasAnnotatedTypeArgument(AutoDsl::class, 1)) to
+                            MapType(findSingular(parameter, index))
                     }
 
                     else -> {
@@ -56,8 +62,10 @@ class ParameterFactory<A, T : A, C : A, P : A>(
             )
         }
 
-    private fun P.hasAnnotatedTypeArgument(annotation: KClass<out Annotation>): Boolean =
-        getTypeArguments().firstOrNull()?.hasAnnotation(annotation) ?: false
+    private fun P.hasAnnotatedTypeArgument(
+        annotation: KClass<out Annotation>,
+        index: Int = 0,
+    ): Boolean = getTypeArguments().getOrNull(index)?.hasAnnotation(annotation) ?: false
 
     private fun findSingular(
         parameter: P,

--- a/processor/src/test/kotlin/com/faendir/kotlin/autodsl/DocTest.kt
+++ b/processor/src/test/kotlin/com/faendir/kotlin/autodsl/DocTest.kt
@@ -18,8 +18,11 @@ class DocTest {
                 """
                 import com.faendir.kotlin.autodsl.DslInspect
                 import com.faendir.kotlin.autodsl.DslMandatory
+                import kotlin.Boolean
                 import kotlin.String
                 import kotlin.Unit
+                import kotlin.collections.MutableCollection
+                import kotlin.collections.MutableMap
 
                 /**
                  * Entity comment
@@ -27,7 +30,7 @@ class DocTest {
                 @DslInspect
                 public class EntityBuilder {
                   /**
-                   * Parameter comment
+                   * Parameter commentParameter comment
                    *
                    * @see Entity.a
                    */
@@ -51,6 +54,18 @@ class DocTest {
                 }
 
                 public inline fun entity(initializer: EntityBuilder.() -> Unit): Entity = EntityBuilder().apply(initializer).build()
+
+                public inline fun MutableCollection<Entity>.add(builder: EntityBuilder.() -> Unit): Boolean = this@add.add(EntityBuilder().apply(builder).build())
+
+                public inline operator fun MutableCollection<Entity>.plusAssign(builder: EntityBuilder.() -> Unit) {
+                  this@plusAssign += EntityBuilder().apply(builder).build()
+                }
+
+                public inline fun <KEY> MutableMap<KEY, Entity>.put(key: KEY, builder: EntityBuilder.() -> Unit): Entity? = this@put.put(key, EntityBuilder().apply(builder).build())
+
+                public inline operator fun <KEY> MutableMap<KEY, Entity>.`set`(key: KEY, builder: EntityBuilder.() -> Unit) {
+                  this@set.put(key, builder)
+                }
 
                 """.trimIndent(),
         )
@@ -70,8 +85,11 @@ class DocTest {
                 """
                 import com.faendir.kotlin.autodsl.DslInspect
                 import com.faendir.kotlin.autodsl.DslMandatory
+                import kotlin.Boolean
                 import kotlin.String
                 import kotlin.Unit
+                import kotlin.collections.MutableCollection
+                import kotlin.collections.MutableMap
 
                 /**
                  * Entity comment
@@ -81,6 +99,7 @@ class DocTest {
                 public class EntityBuilder {
                   /**
                    * Parameter comment
+                   * With second lineParameter comment
                    * With second line
                    *
                    * @see Entity.a
@@ -106,6 +125,18 @@ class DocTest {
                 }
 
                 public inline fun entity(initializer: EntityBuilder.() -> Unit): Entity = EntityBuilder().apply(initializer).build()
+
+                public inline fun MutableCollection<Entity>.add(builder: EntityBuilder.() -> Unit): Boolean = this@add.add(EntityBuilder().apply(builder).build())
+
+                public inline operator fun MutableCollection<Entity>.plusAssign(builder: EntityBuilder.() -> Unit) {
+                  this@plusAssign += EntityBuilder().apply(builder).build()
+                }
+
+                public inline fun <KEY> MutableMap<KEY, Entity>.put(key: KEY, builder: EntityBuilder.() -> Unit): Entity? = this@put.put(key, EntityBuilder().apply(builder).build())
+
+                public inline operator fun <KEY> MutableMap<KEY, Entity>.`set`(key: KEY, builder: EntityBuilder.() -> Unit) {
+                  this@set.put(key, builder)
+                }
 
                 """.trimIndent(),
         )

--- a/processor/src/test/kotlin/com/faendir/kotlin/autodsl/MapTest.kt
+++ b/processor/src/test/kotlin/com/faendir/kotlin/autodsl/MapTest.kt
@@ -44,7 +44,7 @@ class MapTest {
                 import strikt.assertions.hasEntry
 				fun test() {
 					expectThat(entity {
-						a["a"] {
+						a["a"] = {
 							b = "a"
 						}
 					}) {

--- a/processor/src/test/kotlin/com/faendir/kotlin/autodsl/MapTest.kt
+++ b/processor/src/test/kotlin/com/faendir/kotlin/autodsl/MapTest.kt
@@ -1,0 +1,84 @@
+package com.faendir.kotlin.autodsl
+
+import org.junit.jupiter.api.TestFactory
+
+class MapTest {
+    @TestFactory
+    fun `basic map`() =
+        compile(
+            """
+                import com.faendir.kotlin.autodsl.AutoDsl
+				@AutoDsl
+				data class Entity(val a: Map<String, String>) : Map<String, String> by a
+			""",
+            """
+				import strikt.api.expectThat
+                import strikt.assertions.isA
+                import strikt.assertions.hasEntry
+				fun test() {
+					expectThat(entity {
+						a["a"] = "a"
+					}) {
+						with(Entity::a) {
+							isA<Map<String, String>>()
+							hasEntry("a", "a")
+						}
+					}
+				}
+			""",
+        )
+
+    @TestFactory
+    fun `nested map`() =
+        compile(
+            """
+                import com.faendir.kotlin.autodsl.AutoDsl
+				@AutoDsl
+				data class Entity(val a: Map<String, Entity2>) : Map<String, Entity2> by a
+				@AutoDsl
+				data class Entity2(val b: String)
+			""",
+            """
+				import strikt.api.expectThat
+                import strikt.assertions.isA
+                import strikt.assertions.hasEntry
+				fun test() {
+					expectThat(entity {
+						a["a"] {
+							b = "a"
+						}
+					}) {
+						with(Entity::a) {
+							isA<Map<String, Entity2>>()
+							hasEntry("a", Entity2("a"))
+						}
+					}
+				}
+			""",
+        )
+
+    @TestFactory
+    fun `generic map`() =
+        compile(
+            """
+                import com.faendir.kotlin.autodsl.AutoDsl
+				@AutoDsl
+				data class Entity<K, V>(val a: Map<K, V>) : Map<K, V> by a
+			""",
+            """
+				import strikt.api.expectThat
+                import strikt.assertions.isA
+                import strikt.assertions.hasEntry
+				fun test() {
+					expectThat(entity {
+						a["a"] = "a"
+					}) {
+						with(Entity<String, String>::a) {
+							isA<Map<String, String>>()
+							hasEntry("a", "a")
+						}
+					}
+				}
+			""",
+        )
+}


### PR DESCRIPTION
syntax:
```kotlin
@AutoDsl
data class Foo(val foo: String)

@AutoDsl
data class Bar(val bar: Map<String, Foo>)

bar {
    bar["foo"] = {
        foo = "foo"
    }
    bar["bar"] = foo {
        foo = "bar"
    }
    bar("baz") {
        foo = "baz"
    }
    bar += "qux" to foo {
        foo = "qux"
    }
    bar += mapOf("quux" to foo {
        foo = "quux"
    })
}

buildList<Foo> {
    add {
        foo = "foo"
    }
}

buildMap<String, Foo> {
    put("bar") {
        foo = "bar"
    }
}

```